### PR TITLE
[Feat] JWT 인증 필터 구현

### DIFF
--- a/src/main/java/com/moa/moa_server/config/LocalSecurityConfig.java
+++ b/src/main/java/com/moa/moa_server/config/LocalSecurityConfig.java
@@ -1,21 +1,27 @@
 package com.moa.moa_server.config;
 
+import com.moa.moa_server.config.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import static com.moa.moa_server.config.SecurityConstants.ALLOWED_URLS;
 
+@RequiredArgsConstructor
 @Configuration
 @Profile("local")
 public class LocalSecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -27,7 +33,9 @@ public class LocalSecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(ALLOWED_URLS).permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/moa/moa_server/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moa/moa_server/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,55 @@
+package com.moa.moa_server.config.security;
+
+import com.moa.moa_server.domain.auth.service.JwtTokenService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenService jwtTokenService; // 토큰 유효성 검증 및 userId 추출
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // 헤더에서 토큰 추출
+        extractAccessTokenFromHeader(request).ifPresent(token -> {
+            // 토큰 검증 및 userId 추출
+            Long userId = jwtTokenService.validateAndExtractUserId(token);
+
+            // 인증 객체 생성
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userId, null, null);
+            authentication.setDetails(
+                    new WebAuthenticationDetailsSource().buildDetails(request)); // 추가적인 인증 요청 정보 설정
+
+            // SecurityContext에 저장
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        });
+
+        filterChain.doFilter(request, response);
+    }
+
+    private Optional<String> extractAccessTokenFromHeader(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            return Optional.of(authHeader.substring(7));
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- #30 

## 🔥 작업 개요

- 사용자 인증을 위한 JWT 인증 필터 구현

## 🛠️ 작업 상세

- `JwtAuthenticationFilter` 구현: 요청 헤더에서 토큰 추출 후 SecurityContext에 인증 정보 저장
- `JwtTokenService` 내에서 validate와 userId 추출을 하나의 메서드로 통합 (validateAndExtractUserId)  
   → 동일한 JWT 파싱 로직의 중복 제거, 한 번의 파싱으로 검증 + 정보 추출까지 수행하여 효율 및 가독성 개선
- `SecurityConfig`에서 필터 등록 및 세션 관리 정책 stateless로 설정

## 🧪 테스트

- [x] 주요 API 수동 테스트 완료 (200 응답 확인)
- [x] 서버 로그 및 예외 로그 정상

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
