### PR TITLE
[Feat] 로그아웃 API 구현 및 인증 실패 시 401 응답 처리

### DIFF
--- a/src/main/java/com/moa/moa_server/config/LocalSecurityConfig.java
+++ b/src/main/java/com/moa/moa_server/config/LocalSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.moa.moa_server.config;
 
+import com.moa.moa_server.config.security.CustomAuthenticationEntryPoint;
 import com.moa.moa_server.config.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -22,6 +23,7 @@ import static com.moa.moa_server.config.SecurityConstants.ALLOWED_URLS;
 public class LocalSecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -30,6 +32,7 @@ public class LocalSecurityConfig {
                 .cors(Customizer.withDefaults())
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
+                .exceptionHandling(ex -> ex.authenticationEntryPoint(customAuthenticationEntryPoint))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(ALLOWED_URLS).permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/moa/moa_server/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/moa/moa_server/config/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,32 @@
+package com.moa.moa_server.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moa.moa_server.domain.global.dto.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        ApiResponse apiResponse = new ApiResponse("INVALID_TOKEN", null);
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/auth/repository/TokenRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/repository/TokenRepository.java
@@ -12,10 +12,9 @@ import java.util.Optional;
 public interface TokenRepository extends JpaRepository<Token, Long> {
 
     Optional<Token> findByRefreshToken(String refreshToken);
-    void deleteByRefreshToken(String refreshToken);
 
     @Modifying
     @Transactional
     @Query("DELETE FROM Token t WHERE t.user.id = :userId")
-    void deleteByUserId(@Param("userId") Long userId);
+    int deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/moa/moa_server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/service/AuthService.java
@@ -51,4 +51,8 @@ public class AuthService {
         // 응답 반환
         return new TokenRefreshResponseDto(accessToken, expiresIn);
     }
+
+    public boolean logout(Long userId) {
+        return refreshTokenService.deleteRefreshTokenByUserId(userId); // true면 SUCCESS, false면 ALREADY_LOGGED_OUT
+    }
 }

--- a/src/main/java/com/moa/moa_server/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/service/RefreshTokenService.java
@@ -6,6 +6,6 @@ import com.moa.moa_server.domain.user.entity.User;
 public interface RefreshTokenService {
     String issueRefreshToken(User user); // 생성 + 저장
     Token getValidRefreshToken(String refreshToken); // 존재 + 만료 여부 확인 및 반환
-    void deleteRefreshToken(String refreshToken); // 로그아웃
+    boolean deleteRefreshTokenByUserId(Long userId); // 로그아웃
     long getRefreshTokenExpirySeconds();
 }

--- a/src/main/java/com/moa/moa_server/domain/auth/service/impl/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/service/impl/RefreshTokenServiceImpl.java
@@ -59,8 +59,10 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
     }
 
     @Override
-    public void deleteRefreshToken(String refreshToken) {
-        tokenRepository.deleteByRefreshToken(refreshToken);
+    @Transactional
+    public boolean deleteRefreshTokenByUserId(Long userId) {
+        int deletedCount = tokenRepository.deleteByUserId(userId);
+        return deletedCount > 0;
     }
 
     @Override


### PR DESCRIPTION
## 📌 관련 이슈

- #28  

## 🔥 작업 개요

- 로그아웃 기능 구현 및 인증 실패 시 응답 코드 개선 (DELETE /api/v1/auth/logout)

## 🛠️ 작업 상세

- 로그아웃 처리
    - 인증된 사용자의 리프레시 토큰 삭제 (`TokenRepository.deleteByUserId`)
    - 로그아웃 시 쿠키의 max-age를 0으로 설정하여 만료 처리
- 인증 실패 응답 개선 (403 → 401)
    - 유효하지 않거나 만료된 토큰 요청 시 
    - Spring Security 처리 흐름으로 인해, 401 예외를 던짐에도 403 응답을 반환하는 문제
    - `CustomAuthenticationEntryPoint` 추가하여 401 응답하도록 해결

## 🧪 테스트

- [x] 주요 API 수동 테스트 완료 (200, 401 응답 확인)
    - 유효한 토큰으로 로그아웃 요청 → `200 SUCCESS`
    - 이미 로그아웃된 사용자 요청 → `200 ALREADY_LOGGED_OUT`
    - 토큰 없이 요청 → `401 INVALID_TOKEN` (NO_TOKEN이 맞으나, Spring Security에서 구분 불가한 문제)
    - 잘못된/만료된 토큰 요청 → `401 INVALID_TOKEN`
    - 탈퇴한 사용자 요청 → `401 USER_WITHDRAWN`
- [x] 서버 로그 및 예외 로그 정상

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
