### PR TITLE
[Feat] 투표 도메인 엔티티 및 리포지토리 생성

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/auth/repository/TokenRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/repository/TokenRepository.java
@@ -9,7 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-public interface TokenRepository extends JpaRepository<Token, Long> {
+public interface TokenRepository extends JpaRepository<Token, String> {
 
     Optional<Token> findByRefreshToken(String refreshToken);
 

--- a/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
+++ b/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
@@ -1,0 +1,53 @@
+package com.moa.moa_server.domain.group.entity;
+
+import com.moa.moa_server.domain.global.entity.BaseTimeEntity;
+import com.moa.moa_server.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "`group`",
+        uniqueConstraints = @UniqueConstraint(columnNames = "invite_code")
+)
+@SQLDelete(sql = "UPDATE `group` SET deleted_at = NOW() WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
+public class Group extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "name", length = 50, nullable = false)
+    private String name;
+
+    @Column(name = "description", length = 100, nullable = false)
+    private String description;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    @Column(name = "invite_code", length = 20, nullable = false, unique = true)
+    private String inviteCode;
+
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deletedAt;
+
+    public static Group create(User user, String name, String description, String inviteCode) {
+        return Group.builder()
+                .user(user)
+                .name(name)
+                .description(description)
+                .inviteCode(inviteCode)
+                .build();
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/GroupRepository.java
@@ -1,0 +1,7 @@
+package com.moa.moa_server.domain.group.repository;
+
+import com.moa.moa_server.domain.group.entity.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+}

--- a/src/main/java/com/moa/moa_server/domain/user/entity/User.java
+++ b/src/main/java/com/moa/moa_server/domain/user/entity/User.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@Table(name = "user")
+@Table(name = "`user`")
 public class User extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
@@ -1,0 +1,71 @@
+package com.moa.moa_server.domain.vote.entity;
+
+import com.moa.moa_server.domain.global.entity.BaseTimeEntity;
+import com.moa.moa_server.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "vote")
+@SQLDelete(sql = "UPDATE vote SET deleted_at = NOW() WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
+public class Vote extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "group_id", nullable = false)
+//    private Group group;
+
+    @Column(length = 500, nullable = false)
+    private String content;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    @Column(name = "closed_at", nullable = false)
+    private LocalDateTime closedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "vote_status", nullable = false, length = 20)
+    @Builder.Default
+    private VoteStatus voteStatus = VoteStatus.PENDING;
+
+    @Column(name = "admin_vote", nullable = false)
+    @Builder.Default
+    private boolean adminVote = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "vote_type", nullable = false, length = 20)
+    @Builder.Default
+    private VoteType voteType = VoteType.USER;
+
+    @Column(name = "last_anonymous_number", nullable = false)
+    @Builder.Default
+    private int lastAnonymousNumber = 0;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public enum VoteStatus {
+        PENDING, REJECTED, OPEN, CLOSED
+    }
+
+    public enum VoteType {
+        USER, AI, EVENT
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
@@ -1,6 +1,7 @@
 package com.moa.moa_server.domain.vote.entity;
 
 import com.moa.moa_server.domain.global.entity.BaseTimeEntity;
+import com.moa.moa_server.domain.group.entity.Group;
 import com.moa.moa_server.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -27,9 +28,9 @@ public class Vote extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "group_id", nullable = false)
-//    private Group group;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
 
     @Column(length = 500, nullable = false)
     private String content;

--- a/src/main/java/com/moa/moa_server/domain/vote/entity/VoteModerationLog.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/entity/VoteModerationLog.java
@@ -1,0 +1,64 @@
+package com.moa.moa_server.domain.vote.entity;
+
+import com.moa.moa_server.domain.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "vote_moderation_log")
+public class VoteModerationLog extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "vote_id", nullable = false)
+    private Vote vote;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "review_result", length = 20, nullable = false)
+    private ReviewResult reviewResult;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "review_reason", length = 50, nullable = false)
+    private ReviewReason reviewReason;
+
+    @Column(name = "review_detail", length = 500, nullable = false)
+    private String reviewDetail;
+
+    @Column(name = "ai_version", length = 50, nullable = false)
+    private String aiVersion;
+
+    public enum ReviewResult {
+        REJECTED, APPROVED
+    }
+
+    public enum ReviewReason {
+        NONE,
+        OFFENSIVE_LANGUAGE,
+        POLITICAL_CONTENT,
+        SEXUAL_CONTENT,
+        SPAM_ADVERTISEMENT,
+        IMPERSONATION_OR_LEAK,
+        OTHER
+    }
+
+    public static VoteModerationLog create(Vote vote,
+                                           ReviewResult reviewResult,
+                                           ReviewReason reviewReason,
+                                           String reviewDetail,
+                                           String aiVersion) {
+        return VoteModerationLog.builder()
+                .vote(vote)
+                .reviewResult(reviewResult)
+                .reviewReason(reviewReason)
+                .reviewDetail(reviewDetail)
+                .aiVersion(aiVersion)
+                .build();
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/entity/VoteResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/entity/VoteResponse.java
@@ -1,0 +1,40 @@
+package com.moa.moa_server.domain.vote.entity;
+
+import com.moa.moa_server.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "vote_response",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "vote_id"})
+)
+public class VoteResponse {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "vote_id", nullable = false)
+    private Vote vote;
+
+    @Column(name = "option_number", nullable = false)
+    private int optionNumber;
+
+    @CreatedDate
+    @Column(name = "voted_at", nullable = false)
+    private LocalDateTime votedAt;
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/entity/VoteResult.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/entity/VoteResult.java
@@ -1,0 +1,51 @@
+package com.moa.moa_server.domain.vote.entity;
+
+import com.moa.moa_server.domain.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "vote_result",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"vote_id", "option_number"})
+)
+public class VoteResult extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "vote_id", nullable = false)
+    private Vote vote;
+
+    @Column(name = "option_number", nullable = false)
+    private int optionNumber;
+
+    @Column(name = "count", nullable = false)
+    private int count;
+
+    @Column(name = "ratio", precision = 5, scale = 4, nullable = false)
+    private BigDecimal ratio;
+
+    public static VoteResult createInitial(Vote vote, int optionNumber) {
+        return VoteResult.builder()
+                .vote(vote)
+                .optionNumber(optionNumber)
+                .count(0)
+                .ratio(BigDecimal.ZERO)
+                .build();
+    }
+
+    public void update(int count, BigDecimal ratio) {
+        if (this.count != count || this.ratio.compareTo(ratio) != 0) {
+            this.count = count;
+            this.ratio = ratio;
+        }
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/repository/VoteModerationLogRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/repository/VoteModerationLogRepository.java
@@ -1,0 +1,7 @@
+package com.moa.moa_server.domain.vote.repository;
+
+import com.moa.moa_server.domain.vote.entity.VoteModerationLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoteModerationLogRepository extends JpaRepository<VoteModerationLog, Long> {
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/repository/VoteRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/repository/VoteRepository.java
@@ -1,0 +1,7 @@
+package com.moa.moa_server.domain.vote.repository;
+
+import com.moa.moa_server.domain.vote.entity.Vote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResponseRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResponseRepository.java
@@ -1,0 +1,7 @@
+package com.moa.moa_server.domain.vote.repository;
+
+import com.moa.moa_server.domain.vote.entity.VoteResponse;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoteResponseRepository extends JpaRepository<VoteResponse, Long> {
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResultRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResultRepository.java
@@ -1,0 +1,7 @@
+package com.moa.moa_server.domain.vote.repository;
+
+import com.moa.moa_server.domain.vote.entity.VoteResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoteResultRepository extends JpaRepository<VoteResult, Long> {
+}


### PR DESCRIPTION
## 📌 관련 이슈

- #31  

## 🔥 작업 개요

- 투표 도메인 엔티티 및 리포지토리 생성

## 🛠️ 작업 상세

- 투표 도메인 엔티티 및 리포지토리 생성
    - `Vote`: 투표 본문 및 설정
    - `VoteResponse`: 유저가 투표한 항목
    - `VoteResult`: 투표 결과 집계용
    - `VoteModerationLog`: AI 검열 로그
- 그룹 도메인 엔티티 및 리포지토리 생성
    - `Group`: 그룹 (Vote와 연관관계 매핑)

## 🧪 테스트

- [ ] 주요 API 수동 테스트 완료 (해당 PR은 API 구현 전 단계로 테스트 항목 없음)
- [x] 서버 로그 및 예외 로그 정상

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
