### PR TITLE
[Feat] 투표 참여 API 개발

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
@@ -46,7 +46,7 @@ public class VoteController {
             @PathVariable Long voteId,
             @RequestBody VoteSubmitRequest request
     ) {
-        // voteService.submitVote(userId, voteId, request);
+        voteService.submitVote(userId, voteId, request);
         return ResponseEntity.ok(new ApiResponse("SUCCESS", null));
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
@@ -2,6 +2,7 @@ package com.moa.moa_server.domain.vote.controller;
 
 import com.moa.moa_server.domain.global.dto.ApiResponse;
 import com.moa.moa_server.domain.vote.dto.request.VoteCreateRequest;
+import com.moa.moa_server.domain.vote.dto.request.VoteSubmitRequest;
 import com.moa.moa_server.domain.vote.dto.response.VoteCreateResponse;
 import com.moa.moa_server.domain.vote.dto.response.VoteDetailResponse;
 import com.moa.moa_server.domain.vote.service.VoteService;
@@ -37,5 +38,15 @@ public class VoteController {
     ) {
         VoteDetailResponse response = voteService.getVoteDetail(userId, voteId);
         return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
+    }
+
+    @PostMapping("/{voteId}/submit")
+    public ResponseEntity<ApiResponse> submitVote(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long voteId,
+            @RequestBody VoteSubmitRequest request
+    ) {
+        // voteService.submitVote(userId, voteId, request);
+        return ResponseEntity.ok(new ApiResponse("SUCCESS", null));
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/request/VoteSubmitRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/request/VoteSubmitRequest.java
@@ -1,0 +1,5 @@
+package com.moa.moa_server.domain.vote.dto.request;
+
+public record VoteSubmitRequest(
+        int userResponse
+) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
@@ -89,4 +89,8 @@ public class Vote extends BaseTimeEntity {
                 .lastAnonymousNumber(0)
                 .build();
     }
+
+    public boolean isOpen() {
+        return this.voteStatus == VoteStatus.OPEN;
+    }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/entity/VoteResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/entity/VoteResponse.java
@@ -37,4 +37,12 @@ public class VoteResponse {
     @CreatedDate
     @Column(name = "voted_at", nullable = false)
     private LocalDateTime votedAt;
+
+    public static VoteResponse create(Vote vote, User user, int optionNumber) {
+        return VoteResponse.builder()
+                .vote(vote)
+                .user(user)
+                .optionNumber(optionNumber)
+                .build();
+    }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/handler/VoteErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/handler/VoteErrorCode.java
@@ -11,7 +11,10 @@ public enum VoteErrorCode implements BaseErrorCode {
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND),
     NOT_GROUP_MEMBER(HttpStatus.FORBIDDEN),
     VOTE_NOT_FOUND(HttpStatus.NOT_FOUND),
-    FORBIDDEN(HttpStatus.FORBIDDEN);
+    FORBIDDEN(HttpStatus.FORBIDDEN),
+    INVALID_OPTION(HttpStatus.BAD_REQUEST),
+    ALREADY_VOTED(HttpStatus.CONFLICT),
+    VOTE_NOT_OPENED(HttpStatus.FORBIDDEN),;
 
     private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -115,9 +115,9 @@ public class VoteService {
         Vote vote = findVoteOrThrow(voteId);
 
         // 투표 상태 체크
-//        if (!vote.getVoteStatus().isOpen()) {
-//            throw new VoteException(VoteErrorCode.VOTE_NOT_OPENED);
-//        }
+        if (!vote.isOpen()) {
+            throw new VoteException(VoteErrorCode.VOTE_NOT_OPENED);
+        }
 
         // 투표 권한 조회
         Group group = vote.getGroup();

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -10,8 +10,10 @@ import com.moa.moa_server.domain.user.handler.UserException;
 import com.moa.moa_server.domain.user.repository.UserRepository;
 import com.moa.moa_server.domain.user.util.AuthUserValidator;
 import com.moa.moa_server.domain.vote.dto.request.VoteCreateRequest;
+import com.moa.moa_server.domain.vote.dto.request.VoteSubmitRequest;
 import com.moa.moa_server.domain.vote.dto.response.VoteDetailResponse;
 import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.entity.VoteResponse;
 import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
 import com.moa.moa_server.domain.vote.handler.VoteException;
 import com.moa.moa_server.domain.vote.repository.VoteRepository;
@@ -19,6 +21,7 @@ import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
 import com.moa.moa_server.domain.vote.util.VoteValidator;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -79,8 +82,7 @@ public class VoteService {
         AuthUserValidator.validateActive(user);
 
         // 투표 조회
-        Vote vote = voteRepository.findById(voteId)
-                .orElseThrow(() -> new VoteException(VoteErrorCode.VOTE_NOT_FOUND));
+        Vote vote = findVoteOrThrow(voteId);
 
         // 접근 권한 확인
         validateGroupAccess(user, vote);
@@ -96,8 +98,64 @@ public class VoteService {
         );
     }
 
+    @Transactional
+    public void submitVote(Long userId, Long voteId, VoteSubmitRequest request) {
+        // 유저 조회 및 유효성 검사
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        AuthUserValidator.validateActive(user);
+
+        // 응답 값 유효성 검증
+        int response = request.userResponse();
+        if (response < 0 || response > 2) {
+            throw new VoteException(VoteErrorCode.INVALID_OPTION);
+        }
+
+        // 투표 조회
+        Vote vote = findVoteOrThrow(voteId);
+
+        // 투표 상태 체크
+//        if (!vote.getVoteStatus().isOpen()) {
+//            throw new VoteException(VoteErrorCode.VOTE_NOT_OPENED);
+//        }
+
+        // 투표 권한 조회
+        Group group = vote.getGroup();
+        if (!group.isPublicGroup()) {
+            boolean isGroupMember = groupMemberRepository
+                    .findByGroupAndUserIncludingDeleted(group, user)
+                    .filter(m -> m.getDeletedAt() == null)
+                    .isPresent();
+
+            if (!isGroupMember) {
+                throw new VoteException(VoteErrorCode.NOT_GROUP_MEMBER);
+            }
+        }
+
+        // 중복 투표 확인
+        if (voteResponseRepository.existsByVoteAndUser(vote, user)) {
+            throw new VoteException(VoteErrorCode.ALREADY_VOTED);
+        }
+
+        // 투표 응답 저장
+        VoteResponse voteResponse = VoteResponse.create(vote, user, response);
+        try {
+            voteResponseRepository.save(voteResponse);
+        } catch (DataIntegrityViolationException e) {
+            throw new VoteException(VoteErrorCode.ALREADY_VOTED);
+        }
+    }
+
     /**
-     * 그룹에 소속된 유저인지 검사 (등록/수정 등에 사용)
+     * 투표 조회
+     */
+    private Vote findVoteOrThrow(Long voteId) {
+        return voteRepository.findById(voteId)
+                .orElseThrow(() -> new VoteException(VoteErrorCode.VOTE_NOT_FOUND));
+    }
+
+    /**
+     * 그룹에 소속된 유저인지 검사 (등록/참여에 사용)
      */
     private GroupMember validateGroupMembership(User user, Group group) {
         if (group.isPublicGroup()) return null;


### PR DESCRIPTION
## 📌 관련 이슈

- #34 

## 🔥 작업 개요

- 투표 참여 API 구현
- 응답 유효성 검증 및 그룹 접근 권한/투표 상태 확인

## 🛠️ 작업 상세

- 투표 참여 API 구현 (`POST /api/v1/votes/{voteId}/submit`)
    - 컨트롤러 및 서비스 계층 로직 작성
    - 응답 항목 번호(0: 기권, 1: 찬성, 2: 반대) 유효성 검증
    - 투표 상태가 OPEN인 경우에만 참여 가능
    - 비공개 그룹일 경우 그룹 멤버 여부 확인
    - 중복 투표 방지 (vote_id + user_id 유니크 조건 기반)
    - 커스텀 예외 적용 (`INVALID_OPTION`, `VOTE_NOT_OPENED`, `ALREADY_VOTED`, `NOT_GROUP_MEMBER`, `VOTE_NOT_FOUND`)

## 🧪 테스트

- [x] 주요 API 수동 테스트 완료
    - 성공 케이스
        - 공개 그룹 투표 참여 
        - 비공개 그룹 투표 참여    
    - 실패 케이스
        - 투표가 존재하지 않는 경우 → `VOTE_NOT_FOUND`
        - 유효하지 않은 응답 값 → `INVALID_OPTION`
        - 투표가 열려있지 않은 경우 → `VOTE_NOT_OPENED`
        - 그룹 멤버가 아닌 경우 → `NOT_GROUP_MEMBER` 
        - 중복 투표 시도 → `ALREADY_VOTED`
- [x] DB 연동 동작 확인 (엔티티 저장, 삭제, 갱신 등)
- [x] 의도한 비즈니스 로직 흐름 정상 동작 확인 (e.g. 중복 방지, 조건 분기 등)
- [x] 서버 로그 및 예외 로그 확인 완료

## 💬 기타 논의 사항

- 투표 등록자도 참여 가능한가? 
    - ‘투표 등록자도 한 표 행사 가능’하다고 설정하고 개발하였음. 

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
