### PR TITLE
[Feat] 투표 결과 조회 API 개발

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
@@ -32,15 +32,6 @@ public class VoteController {
                 .body(new ApiResponse("SUCCESS", new VoteCreateResponse(voteId)));
     }
 
-    @GetMapping("/{voteId}")
-    public ResponseEntity<ApiResponse> getVoteDetail(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long voteId
-    ) {
-        VoteDetailResponse response = voteService.getVoteDetail(userId, voteId);
-        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
-    }
-
     @PostMapping("/{voteId}/submit")
     public ResponseEntity<ApiResponse> submitVote(
             @AuthenticationPrincipal Long userId,
@@ -49,6 +40,15 @@ public class VoteController {
     ) {
         voteService.submitVote(userId, voteId, request);
         return ResponseEntity.ok(new ApiResponse("SUCCESS", null));
+    }
+
+    @GetMapping("/{voteId}")
+    public ResponseEntity<ApiResponse> getVoteDetail(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long voteId
+    ) {
+        VoteDetailResponse response = voteService.getVoteDetail(userId, voteId);
+        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
     }
 
     @GetMapping("/{voteId}/result")

--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
@@ -5,6 +5,7 @@ import com.moa.moa_server.domain.vote.dto.request.VoteCreateRequest;
 import com.moa.moa_server.domain.vote.dto.request.VoteSubmitRequest;
 import com.moa.moa_server.domain.vote.dto.response.VoteCreateResponse;
 import com.moa.moa_server.domain.vote.dto.response.VoteDetailResponse;
+import com.moa.moa_server.domain.vote.dto.response.VoteResultResponse;
 import com.moa.moa_server.domain.vote.service.VoteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -48,5 +49,14 @@ public class VoteController {
     ) {
         voteService.submitVote(userId, voteId, request);
         return ResponseEntity.ok(new ApiResponse("SUCCESS", null));
+    }
+
+    @GetMapping("/{voteId}/result")
+    public ResponseEntity<ApiResponse> getVoteResult(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long voteId
+    ) {
+        VoteResultResponse response = voteService.getVoteResult(userId, voteId);
+        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteOptionResult.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteOptionResult.java
@@ -1,0 +1,7 @@
+package com.moa.moa_server.domain.vote.dto.response;
+
+public record VoteOptionResult(
+        int optionNumber,
+        int count,
+        int ratio
+) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteResultResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteResultResponse.java
@@ -1,0 +1,10 @@
+package com.moa.moa_server.domain.vote.dto.response;
+
+import java.util.List;
+
+public record VoteResultResponse (
+        Long voteId,
+        Integer userResponse,
+        int totalCount,
+        List<VoteOptionResult> results
+) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResponseRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResponseRepository.java
@@ -5,6 +5,11 @@ import com.moa.moa_server.domain.vote.entity.Vote;
 import com.moa.moa_server.domain.vote.entity.VoteResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface VoteResponseRepository extends JpaRepository<VoteResponse, Long> {
     boolean existsByVoteAndUser(Vote vote, User user);
+    Optional<VoteResponse> findByVoteAndUser(Vote vote, User user);
+    List<VoteResponse> findAllByVote(Vote vote);
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -139,7 +139,8 @@ public class VoteService {
         // 투표 조회
         Vote vote = findVoteOrThrow(voteId);
 
-        // 접근 권한 확인
+        // 상태/권한 검사
+        validateVoteReadable(vote);
         validateVoteAccess(user, vote);
 
         return new VoteDetailResponse(
@@ -163,7 +164,8 @@ public class VoteService {
         // 투표 조회
         Vote vote = findVoteOrThrow(voteId);
 
-        // 접근 권한 확인
+        // 상태/권한 검사
+        validateVoteReadable(vote);
         validateVoteAccess(user, vote);
 
         // 사용자 응답 조회 (없으면 null)
@@ -220,7 +222,20 @@ public class VoteService {
     }
 
     /**
-     * 투표 상세 조회 권한 검사 (투표 상세 페이지 읽기 접근에 사용)
+     * 투표 조회 가능한 상태인지 검사 (내용, 결과, 댓글 읽기)
+     * 허용 상태: OPEN, CLOSED
+     */
+    private void validateVoteReadable(Vote vote) {
+        if (vote.getVoteStatus() != Vote.VoteStatus.OPEN &&
+                vote.getVoteStatus() != Vote.VoteStatus.CLOSED) {
+            throw new VoteException(VoteErrorCode.FORBIDDEN);
+        }
+    }
+
+    /**
+     * 투표 조회 권한 검사 (내용, 결과, 댓글 읽기)
+     * 조건: 등록자이거나 참여자여야 함
+     * * top3 투표는 추후 그룹 멤버 여부로도 허용 예정
      */
     private void validateVoteAccess(User user, Vote vote) {
         if (isVoteAuthor(user, vote)) return;

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -167,37 +167,36 @@ public class VoteService {
         validateVoteAccess(user, vote);
 
         // 사용자 응답 조회 (없으면 null)
-//        Optional<VoteResponse> userVoteResponse = voteResponseRepository.findByVoteAndUser(vote, user);
-//        Integer userResponse = userVoteResponse.map(VoteResponse::getOptionNumber).orElse(null);
-//
-//        // 전체 응답 조회
-//        List<VoteResponse> responses = voteResponseRepository.findAllByVote(vote);
-//        int totalCount = responses.size();
-//
-//        // 항목별 집계 (0: 기권 제외)
-//        Map<Integer, Long> grouped = responses.stream()
-//                .filter(vr -> vr.getOptionNumber() > 0)
-//                .collect(Collectors.groupingBy(
-//                        VoteResponse::getOptionNumber,
-//                        Collectors.counting()
-//                ));
-//
-//        List<VoteOptionResult> results = grouped.entrySet().stream()
-//                .sorted(Map.Entry.comparingByKey())
-//                .map(e -> new VoteOptionResult(
-//                        e.getKey(),
-//                        e.getValue().intValue(),
-//                        totalCount == 0 ? 0 : (int) ((e.getValue() * 100.0) / totalCount)
-//                ))
-//                .collect(Collectors.toList());
-//
-//        return new VoteResultResponse(
-//                voteId,
-//                userResponse,
-//                totalCount,
-//                results
-//        );
-        return null;
+        Optional<VoteResponse> userVoteResponse = voteResponseRepository.findByVoteAndUser(vote, user);
+        Integer userResponse = userVoteResponse.map(VoteResponse::getOptionNumber).orElse(null);
+
+        // 전체 응답 조회
+        List<VoteResponse> responses = voteResponseRepository.findAllByVote(vote);
+        int totalCount = responses.size();
+
+        // 항목별 집계 (0: 기권 제외)
+        Map<Integer, Long> grouped = responses.stream()
+                .filter(vr -> vr.getOptionNumber() > 0)
+                .collect(Collectors.groupingBy(
+                        VoteResponse::getOptionNumber,
+                        Collectors.counting()
+                ));
+
+        List<VoteOptionResult> results = grouped.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> new VoteOptionResult(
+                        e.getKey(),
+                        e.getValue().intValue(),
+                        totalCount == 0 ? 0 : (int) ((e.getValue() * 100.0) / totalCount)
+                ))
+                .collect(Collectors.toList());
+
+        return new VoteResultResponse(
+                voteId,
+                userResponse,
+                totalCount,
+                results
+        );
     }
 
     /**

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -235,12 +235,12 @@ public class VoteService {
 
     /**
      * 투표 조회 권한 검사 (내용, 결과, 댓글 읽기)
-     * 조건: 등록자이거나 참여자여야 함
+     * 조건: 등록자이거나 참여자(기권 불가)여야 함
      * * top3 투표는 추후 그룹 멤버 여부로도 허용 예정
      */
     private void validateVoteAccess(User user, Vote vote) {
         if (isVoteAuthor(user, vote)) return;
-        if (hasParticipated(user, vote)) return;
+        if (hasParticipatedWithValidOption(user, vote)) return;
 
         // TODO: top3 투표일 경우 isGroupMember 검사 후 허용
         throw new VoteException(VoteErrorCode.FORBIDDEN);
@@ -250,7 +250,9 @@ public class VoteService {
         return vote.getUser().equals(user);
     }
 
-    private boolean hasParticipated(User user, Vote vote) {
-        return voteResponseRepository.existsByVoteAndUser(vote, user);
+    private boolean hasParticipatedWithValidOption(User user, Vote vote) {
+        return voteResponseRepository.findByVoteAndUser(vote, user)
+                .map(vr -> vr.getOptionNumber() > 0)
+                .orElse(false);
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -12,6 +12,7 @@ import com.moa.moa_server.domain.user.util.AuthUserValidator;
 import com.moa.moa_server.domain.vote.dto.request.VoteCreateRequest;
 import com.moa.moa_server.domain.vote.dto.request.VoteSubmitRequest;
 import com.moa.moa_server.domain.vote.dto.response.VoteDetailResponse;
+import com.moa.moa_server.domain.vote.dto.response.VoteResultResponse;
 import com.moa.moa_server.domain.vote.entity.Vote;
 import com.moa.moa_server.domain.vote.entity.VoteResponse;
 import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
@@ -144,6 +145,12 @@ public class VoteService {
         } catch (DataIntegrityViolationException e) {
             throw new VoteException(VoteErrorCode.ALREADY_VOTED);
         }
+    }
+
+    @Transactional
+    public VoteResultResponse getVoteResult(Long userId, Long voteId) {
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
## 📌 관련 이슈

- #35

## 🔥 작업 개요

- 투표 결과 조회 API 구현
- 투표 상태 및 사용자 권한 검증
- 실시간 집계 기능 적용

## 🛠️ 작업 상세

- 투표 결과 조회 API 구현 (`GET /api/v1/votes/{voteId}/result`)
    - 컨트롤러 및 서비스 계층 로직 작성
    - 투표 상태가 OPEN, CLOSED인 경우에만 조회 가능
    - 등록자이거나 참여자(응답값 1, 2)인 경우에만 조회 가능 
        - 기권 응답(0)은 참여자로 간주하지 않음
    - 실시간 집계 처리 
        - 전체 응답 수 집계 (`totalCount`)
        - 항목별 응답 수 및 비율 집계 (`count`, `ratio`)
    - 커스텀 예외 적용 (`VOTE_NOT_FOUND`, `FORBIDDEN`)

## 🧪 테스트

- [x] 주요 API 수동 테스트 완료
    - 성공 케이스
        - 투표 등록자 (미참여 가능) 
        - 투표 참여자 (1 또는 2로 응답한 경우)
    - 실패 케이스
        - 투표가 존재하지 않는 경우 → `VOTE_NOT_FOUND`
        - 투표 상태가 OPEN, CLOSED가 아닌 경우 → `FORBIDDEN`
        - 투표 등록자나 참여자가 아닌 경우 (그룹 멤버이더라도 조회 불가) → `FORBIDDEN`
        - 기권자(0번 응답) → `FORBIDDEN`
- [x] DB 연동 동작 확인 (엔티티 저장, 삭제, 갱신 등)
- [x] 의도한 비즈니스 로직 흐름 정상 동작 확인 (e.g. 중복 방지, 조건 분기 등)
- [x] 서버 로그 및 예외 로그 확인 완료

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
