### PR TITLE
[Feat] Dev 환경에 Jwt 인증 및 예외 처리 필터 적용

### DIFF
--- a/src/main/java/com/moa/moa_server/config/DevSecurityConfig.java
+++ b/src/main/java/com/moa/moa_server/config/DevSecurityConfig.java
@@ -1,16 +1,20 @@
 package com.moa.moa_server.config;
 
+import com.moa.moa_server.config.security.CustomAuthenticationEntryPoint;
+import com.moa.moa_server.config.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -19,6 +23,7 @@ import java.util.List;
 
 import static com.moa.moa_server.config.SecurityConstants.ALLOWED_URLS;
 
+@RequiredArgsConstructor
 @EnableWebSecurity
 @Configuration
 @Profile("dev")
@@ -27,6 +32,9 @@ public class DevSecurityConfig {
     @Value("${frontend.url}")
     private String frontendUrl;
 
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, CorsConfigurationSource corsConfigurationSource) throws Exception {
         http
@@ -34,10 +42,13 @@ public class DevSecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
+                .exceptionHandling(ex -> ex.authenticationEntryPoint(customAuthenticationEntryPoint))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(ALLOWED_URLS).permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -23,3 +23,7 @@ ai:
 mock:
   ai:
     enabled: false
+
+logging:
+  level:
+    org.springframework.security: DEBUG


### PR DESCRIPTION
## 📌 관련 이슈

- #36

## 🔥 작업 개요

- dev 환경에서 Spring Security 설정 개선
- JWT 인증 및 예외 처리 필터 적용

## 🛠️ 작업 상세

- `DevSecurityConfig`에 다음 항목 추가
    - `JwtAuthenticationFilter` 적용
    - `CustomAuthenticationEntryPoint` 등록
    - 세션 정책을 `STATELESS`로 설정
- 기존 `LocalSecurityConfig` 구조와 통일되도록 설정 정리

## 🧪 테스트

- [x] 로컬 환경에서 동일 구조로 기능 정상 작동 확인
    - 인증 헤더 포함 시 필터 동작 정상
    - 미인증 요청 시 401 응답 및 커스텀 에러 메시지 확인
- [x] 서버 로그 및 필터 흐름 문제 없음 확인
- [x] 현재 브랜치 배포 후 CORS 및 인증 흐름 이상 없음 확인
    - `frontend.url` 기반 CORS 정책 정상 작동

## 💬 기타 논의 사항

- 별도의 브랜치(feature/47-dev-security-jwt)에서 dev 설정 테스트 후 dev 브랜치에 병합 진행

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
