### PR TITLE
[Feat] 가입한 그룹 라벨 조회 API 개발

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/global/cursor/GroupNameGroupIdCursor.java
+++ b/src/main/java/com/moa/moa_server/domain/global/cursor/GroupNameGroupIdCursor.java
@@ -1,0 +1,33 @@
+package com.moa.moa_server.domain.global.cursor;
+
+import com.moa.moa_server.domain.user.handler.UserErrorCode;
+import com.moa.moa_server.domain.user.handler.UserException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public record GroupNameGroupIdCursor(String groupName, Long groupId) {
+
+    /**
+     * "groupName_groupId" 형식의 커서를 파싱
+     */
+    public static GroupNameGroupIdCursor parse(String cursor) {
+        try {
+            String[] parts = cursor.split("_");
+            if (parts.length != 2) {
+                log.warn("[GroupNameGroupIdCursor#parse] Invalid format: '{}'", cursor);
+                throw new UserException(UserErrorCode.INVALID_CURSOR_FORMAT);
+            }
+            return new GroupNameGroupIdCursor(
+                    parts[0],
+                    Long.parseLong(parts[1])
+            );
+        } catch (NumberFormatException e) {
+            log.warn("[GroupNameGroupIdCursor#parse] Failed to parse groupId from cursor '{}': {}", cursor, e.toString());
+            throw new UserException(UserErrorCode.INVALID_CURSOR_FORMAT);
+        }
+    }
+
+    public String encode() {
+        return groupName + "_" + groupId;
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>, GroupMemberRepositoryCustom {
     @Query("SELECT gm FROM GroupMember gm WHERE gm.group = :group AND gm.user = :user")
     Optional<GroupMember> findByGroupAndUserIncludingDeleted(Group group, User user);
 

--- a/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepositoryCustom.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.moa.moa_server.domain.group.repository;
+
+import com.moa.moa_server.domain.global.cursor.GroupNameGroupIdCursor;
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.user.entity.User;
+import jakarta.annotation.Nullable;
+
+import java.util.List;
+
+public interface GroupMemberRepositoryCustom {
+    List<Group> findJoinedGroupLabels(User user, @Nullable GroupNameGroupIdCursor cursor, int size);
+}

--- a/src/main/java/com/moa/moa_server/domain/group/repository/impl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/impl/GroupMemberRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.moa.moa_server.domain.group.repository.impl;
+
+import com.moa.moa_server.domain.global.cursor.GroupNameGroupIdCursor;
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.entity.QGroup;
+import com.moa.moa_server.domain.group.entity.QGroupMember;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.group.repository.GroupMemberRepositoryCustom;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Group> findJoinedGroupLabels(User user, @Nullable GroupNameGroupIdCursor cursor, int size) {
+        QGroup group = QGroup.group;
+        QGroupMember member = QGroupMember.groupMember;
+
+        BooleanBuilder builder = new BooleanBuilder()
+                .and(member.user.eq(user))
+                .and(member.deletedAt.isNull());
+
+        if (cursor != null) {
+            builder.and(
+                    group.name.gt(cursor.groupName())
+                            .or(group.name.eq(cursor.groupName()).and(group.id.gt(cursor.groupId())))
+            );
+        }
+
+        return queryFactory
+                .select(group)
+                .from(member)
+                .join(member.group, group)
+                .where(builder)
+                .orderBy(group.name.asc(), group.id.asc())
+                .limit(size)
+                .fetch();
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
+++ b/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
@@ -1,0 +1,30 @@
+package com.moa.moa_server.domain.user.controller;
+
+import com.moa.moa_server.domain.global.dto.ApiResponse;
+import com.moa.moa_server.domain.user.dto.response.GroupLabelResponse;
+import com.moa.moa_server.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/groups/labels")
+    public ResponseEntity<ApiResponse> getJoinedGroupLabels(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) Integer size
+    ) {
+        GroupLabelResponse response = userService.getJoinedGroupLabels(userId, cursor, size);
+        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/user/dto/response/GroupLabel.java
+++ b/src/main/java/com/moa/moa_server/domain/user/dto/response/GroupLabel.java
@@ -1,0 +1,13 @@
+package com.moa.moa_server.domain.user.dto.response;
+
+import com.moa.moa_server.domain.group.entity.Group;
+
+public record GroupLabel(
+        Long groupId,
+        String name
+) {
+
+    public static GroupLabel from(Group group) {
+        return new GroupLabel(group.getId(), group.getName());
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/user/dto/response/GroupLabelResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/user/dto/response/GroupLabelResponse.java
@@ -1,0 +1,10 @@
+package com.moa.moa_server.domain.user.dto.response;
+
+import java.util.List;
+
+public record GroupLabelResponse(
+        List<GroupLabel> groups,
+        String nextCursor,
+        boolean hasNext,
+        int size
+){}

--- a/src/main/java/com/moa/moa_server/domain/user/handler/UserErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/user/handler/UserErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements BaseErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND),
-    USER_WITHDRAWN(HttpStatus.UNAUTHORIZED);
+    USER_WITHDRAWN(HttpStatus.UNAUTHORIZED),
+    INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST),;
 
     private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
+++ b/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
@@ -3,7 +3,6 @@ package com.moa.moa_server.domain.user.service;
 import com.moa.moa_server.domain.global.cursor.GroupNameGroupIdCursor;
 import com.moa.moa_server.domain.group.entity.Group;
 import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
-import com.moa.moa_server.domain.group.repository.GroupMemberRepositoryCustom;
 import com.moa.moa_server.domain.group.service.GroupService;
 import com.moa.moa_server.domain.user.dto.response.GroupLabel;
 import com.moa.moa_server.domain.user.dto.response.GroupLabelResponse;

--- a/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
+++ b/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
@@ -1,0 +1,66 @@
+package com.moa.moa_server.domain.user.service;
+
+import com.moa.moa_server.domain.global.cursor.GroupNameGroupIdCursor;
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
+import com.moa.moa_server.domain.group.repository.GroupMemberRepositoryCustom;
+import com.moa.moa_server.domain.group.service.GroupService;
+import com.moa.moa_server.domain.user.dto.response.GroupLabel;
+import com.moa.moa_server.domain.user.dto.response.GroupLabelResponse;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.handler.UserErrorCode;
+import com.moa.moa_server.domain.user.handler.UserException;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.user.util.AuthUserValidator;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private static final int DEFAULT_PAGE_SIZE = 10;
+
+    private final UserRepository userRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    private final GroupService groupService;
+
+    @Transactional(readOnly = true)
+    public GroupLabelResponse getJoinedGroupLabels(Long userId, @Nullable String cursor, @Nullable Integer size) {
+        int pageSize = (size == null || size <= 0) ? DEFAULT_PAGE_SIZE : size;
+        GroupNameGroupIdCursor parsedCursor = cursor != null ? GroupNameGroupIdCursor.parse(cursor) : null;
+
+        // 유저 조회 및 검증
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        AuthUserValidator.validateActive(user);
+
+        // 그룹 목록 조회
+        List<Group> groups = new LinkedList<>(groupMemberRepository.findJoinedGroupLabels(user, parsedCursor, pageSize + 1));
+
+        // 첫 페이지인 경우 공개 그룹을 제일 앞에 추가
+        if (cursor == null) {
+            Group publicGroup = groupService.getPublicGroup();
+            groups.addFirst(publicGroup);
+        }
+
+        // 응답 구성
+        boolean hasNext = groups.size() > pageSize;
+        if (hasNext) groups = groups.subList(0, pageSize);
+
+        String nextCursor = groups.isEmpty() ? null :
+                new GroupNameGroupIdCursor(groups.getLast().getName(), groups.getLast().getId()).encode();
+
+        List<GroupLabel> labels = groups.stream()
+                .map(GroupLabel::from)
+                .toList();
+
+        return new GroupLabelResponse(labels, nextCursor, hasNext, labels.size());
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- #56

## 🔥 작업 개요

- 사용자가 가입한 그룹들의 라벨을 조회하는 API 구현
    - 본 API는 경량 응답을 위한 별도 API로, 그룹 선택 토글 등에서 재사용 예정

## 🛠️ 작업 상세

- 가입한 그룹 라벨 조회 API 구현 (`GET /api/v1/user/groups/labels`)
    - 사용자가 가입한 그룹의 ID와 이름(라벨) 목록 조회
    - 커서 기반 페이지네이션 (groupName ASC, groupId ASC) 적용
    - 첫 페이지 요청 시, 공개 그룹(groupId1=1)을 항상 최상단에 포함
- 응답 DTO 설계 및 적용 (`GroupLabel`, `GroupLabelResponse`)

## 🧪 테스트

- [x] 주요 API 수동 테스트 완료
    - 기본 요청 (커서 없음): 공개 그룹 포함 + 가입 그룹 정렬 확인
    - 커서 포함 요청: 다음 페이지 정상 조회, hasNext 여부 확인
    - 정렬 확인: 이름 기준 가나다/알파벳순
    - 가입한 그룹이 하나도 없는 경우: 공개 그룹만 포함된 응답 확인
- [x] DB 연동 동작 확인 (엔티티 저장, 삭제, 갱신 등)
- [x] 의도한 비즈니스 로직 흐름 정상 동작 확인 (e.g. 중복 방지, 조건 분기 등)
- [x] 서버 로그 및 예외 로그 확인 완료

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
