### PR TITLE
[Feat] 가입한 그룹 목록 조회 API 개발

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepositoryCustom.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.moa.moa_server.domain.group.repository;
 
 import com.moa.moa_server.domain.global.cursor.GroupNameGroupIdCursor;
 import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.entity.GroupMember;
 import com.moa.moa_server.domain.user.entity.User;
 import jakarta.annotation.Nullable;
 
@@ -9,4 +10,5 @@ import java.util.List;
 
 public interface GroupMemberRepositoryCustom {
     List<Group> findJoinedGroupLabels(User user, @Nullable GroupNameGroupIdCursor cursor, int size);
+    List<GroupMember> findJoinedGroups(User user, @Nullable GroupNameGroupIdCursor cursor, int size);
 }

--- a/src/main/java/com/moa/moa_server/domain/group/repository/impl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/impl/GroupMemberRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.moa.moa_server.domain.group.repository.impl;
 
 import com.moa.moa_server.domain.global.cursor.GroupNameGroupIdCursor;
 import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.entity.GroupMember;
 import com.moa.moa_server.domain.group.entity.QGroup;
 import com.moa.moa_server.domain.group.entity.QGroupMember;
 import com.moa.moa_server.domain.user.entity.User;
@@ -40,6 +41,33 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .select(group)
                 .from(member)
                 .join(member.group, group)
+                .where(builder)
+                .orderBy(group.name.asc(), group.id.asc())
+                .limit(size)
+                .fetch();
+    }
+
+    @Override
+    public List<GroupMember> findJoinedGroups(User user, @Nullable GroupNameGroupIdCursor cursor, int size) {
+        QGroupMember member = QGroupMember.groupMember;
+        QGroup group = QGroup.group;
+
+        BooleanBuilder builder = new BooleanBuilder()
+                .and(member.user.eq(user))
+                .and(member.deletedAt.isNull())
+                .and(group.id.ne(1L)); // 공개 그룹 제외
+
+        if (cursor != null) {
+            builder.and(
+                    group.name.gt(cursor.groupName())
+                            .or(group.name.eq(cursor.groupName())
+                                    .and(group.id.gt(cursor.groupId())))
+            );
+        }
+
+        return queryFactory
+                .selectFrom(member)
+                .join(member.group, group).fetchJoin()
                 .where(builder)
                 .orderBy(group.name.asc(), group.id.asc())
                 .limit(size)

--- a/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
+++ b/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.moa.moa_server.domain.user.controller;
 
 import com.moa.moa_server.domain.global.dto.ApiResponse;
 import com.moa.moa_server.domain.user.dto.response.GroupLabelResponse;
+import com.moa.moa_server.domain.user.dto.response.JoinedGroupResponse;
 import com.moa.moa_server.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,16 @@ public class UserController {
             @RequestParam(required = false) Integer size
     ) {
         GroupLabelResponse response = userService.getJoinedGroupLabels(userId, cursor, size);
+        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
+    }
+
+    @GetMapping("/groups")
+    public ResponseEntity<ApiResponse> getJoinedGroups(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) Integer size
+    ) {
+        JoinedGroupResponse response = userService.getJoinedGroups(userId, cursor, size);
         return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/user/dto/response/GroupDetail.java
+++ b/src/main/java/com/moa/moa_server/domain/user/dto/response/GroupDetail.java
@@ -1,0 +1,28 @@
+package com.moa.moa_server.domain.user.dto.response;
+
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.entity.GroupMember;
+
+public record GroupDetail(
+        Long groupId,
+        String name,
+        String description,
+        String imageUrl,
+        String inviteCode,
+        String role
+) {
+    public static GroupDetail from(Group group, GroupMember.Role role) {
+        return new GroupDetail(
+                group.getId(),
+                group.getName(),
+                group.getDescription(),
+                group.getImageUrl(),
+                group.getInviteCode(),
+                role.name()
+        );
+    }
+
+    public static GroupDetail from(GroupMember member) {
+        return from(member.getGroup(), member.getRole());
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/user/dto/response/JoinedGroupResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/user/dto/response/JoinedGroupResponse.java
@@ -1,0 +1,10 @@
+package com.moa.moa_server.domain.user.dto.response;
+
+import java.util.List;
+
+public record JoinedGroupResponse(
+    List<GroupDetail> groups,
+    String nextCursor,
+    boolean hasNext,
+    int size
+) {}


### PR DESCRIPTION
## 📌 관련 이슈

- #55

## 🔥 작업 개요

- 사용자가 가입한 그룹들의 상세 정보를 조회하는 API 구현

## 🛠️ 작업 상세

- 가입한 그룹 목록 조회 API 구현 (`GET /api/v1/user/groups`)
    - 사용자가 가입한 그룹들의 상세 정보 조회 (이름, 설명, 이미지, 초대 코드, 사용자 역할 등)
    - 커서 기반 페이지네이션 (groupName ASC, groupId ASC) 적용
    - 공개 그룹(groupId1=1)은 응답에서 제외 
- 응답 DTO 설계 및 적용 (`GroupDetail`, `JoinedGroupResponse`)

## 🧪 테스트

- [x] 주요 API 수동 테스트 완료
    - 기본 요청 (커서 없음): 가입한 그룹 정상 조회, 정렬 확인
    - 커서 포함 요청: 다음 페이지 정상 조회, hasNext 여부 확인
    - 정렬 확인: 이름 기준 가나다/알파벳순
    - 가입한 그룹이 하나도 없는 경우: 빈 목록 응답
- [x] DB 연동 동작 확인 (엔티티 저장, 삭제, 갱신 등)
- [x] 의도한 비즈니스 로직 흐름 정상 동작 확인 (e.g. 중복 방지, 조건 분기 등)
- [x] 서버 로그 및 예외 로그 확인 완료

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
