### PR TITLE
[Feat] 그룹 가입 API 개발

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/group/controller/GroupController.java
+++ b/src/main/java/com/moa/moa_server/domain/group/controller/GroupController.java
@@ -1,0 +1,33 @@
+package com.moa.moa_server.domain.group.controller;
+
+import com.moa.moa_server.domain.global.dto.ApiResponse;
+import com.moa.moa_server.domain.group.dto.request.GroupJoinRequest;
+import com.moa.moa_server.domain.group.dto.response.GroupJoinResponse;
+import com.moa.moa_server.domain.group.service.GroupService;
+import com.moa.moa_server.domain.vote.dto.request.VoteCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/groups")
+public class GroupController {
+
+    private final GroupService groupService;
+
+    @PostMapping("/join")
+    public ResponseEntity<ApiResponse> joinGroup(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody GroupJoinRequest request
+    ) {
+        GroupJoinResponse response = groupService.joinGroup(userId, request);
+        return ResponseEntity
+                .status(201)
+                .body(new ApiResponse("SUCCESS", response));
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/group/dto/request/GroupJoinRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/group/dto/request/GroupJoinRequest.java
@@ -1,0 +1,5 @@
+package com.moa.moa_server.domain.group.dto.request;
+
+public record GroupJoinRequest(
+        String inviteCode
+) {}

--- a/src/main/java/com/moa/moa_server/domain/group/dto/response/GroupJoinResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/group/dto/response/GroupJoinResponse.java
@@ -1,0 +1,7 @@
+package com.moa.moa_server.domain.group.dto.response;
+
+public record GroupJoinResponse(
+        Long groupId,
+        String groupName,
+        String role
+) {}

--- a/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
@@ -7,7 +7,8 @@ public enum GroupErrorCode implements BaseErrorCode {
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND),
     INVALID_CODE_FORMAT(HttpStatus.BAD_REQUEST),
     INVITE_CODE_NOT_FOUND(HttpStatus.NOT_FOUND),
-    ALREADY_JOINED(HttpStatus.CONFLICT);
+    ALREADY_JOINED(HttpStatus.CONFLICT),
+    CANNOT_JOIN_PUBLIC_GROUP(HttpStatus.BAD_REQUEST),;
 
     private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
@@ -4,7 +4,10 @@ import com.moa.moa_server.domain.global.exception.BaseErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum GroupErrorCode implements BaseErrorCode {
-    GROUP_NOT_FOUND(HttpStatus.NOT_FOUND),;
+    GROUP_NOT_FOUND(HttpStatus.NOT_FOUND),
+    INVALID_CODE_FORMAT(HttpStatus.BAD_REQUEST),
+    INVITE_CODE_NOT_FOUND(HttpStatus.NOT_FOUND),
+    ALREADY_JOINED(HttpStatus.CONFLICT);
 
     private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/group/handler/GroupException.java
+++ b/src/main/java/com/moa/moa_server/domain/group/handler/GroupException.java
@@ -1,0 +1,8 @@
+package com.moa.moa_server.domain.group.handler;
+
+import com.moa.moa_server.domain.global.exception.BaseErrorCode;
+import com.moa.moa_server.domain.global.exception.BaseException;
+
+public class GroupException extends BaseException {
+    public GroupException(BaseErrorCode errorCode) { super(errorCode); }
+}

--- a/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepository.java
@@ -11,11 +11,14 @@ import java.util.List;
 import java.util.Optional;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>, GroupMemberRepositoryCustom {
-    @Query("SELECT gm FROM GroupMember gm WHERE gm.group = :group AND gm.user = :user")
-    Optional<GroupMember> findByGroupAndUserIncludingDeleted(Group group, User user);
+
+    // 탈퇴하지 않은 그룹 멤버 조회 (@Where(clause = "deleted_at IS NULL")가 적용되어 GroupMember가 삭제되지 않은 경우만 조회됨)
+    Optional<GroupMember> findByGroupAndUser(Group group, User user);
+
+    // soft delete된 멤버도 포함하여 조회
+    @Query(value = "SELECT * FROM group_member WHERE group_id = :groupId AND user_id = :userId", nativeQuery = true)
+    Optional<GroupMember> findByGroupAndUserIncludingDeleted(@Param("groupId") Long groupId, @Param("userId") Long userId);
 
     @Query("SELECT gm.group FROM GroupMember gm WHERE gm.user = :user AND gm.deletedAt IS NULL")
     List<Group> findAllActiveGroupsByUser(@Param("user") User user);
-
-    boolean existsByUserAndGroupAndDeletedAtIsNull(User user, Group group);
 }

--- a/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepository.java
@@ -16,4 +16,6 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>,
 
     @Query("SELECT gm.group FROM GroupMember gm WHERE gm.user = :user AND gm.deletedAt IS NULL")
     List<Group> findAllActiveGroupsByUser(@Param("user") User user);
+
+    boolean existsByUserAndGroupAndDeletedAtIsNull(User user, Group group);
 }

--- a/src/main/java/com/moa/moa_server/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/GroupRepository.java
@@ -3,5 +3,8 @@ package com.moa.moa_server.domain.group.repository;
 import com.moa.moa_server.domain.group.entity.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface GroupRepository extends JpaRepository<Group, Long> {
+    Optional<Group> findByInviteCode(String inviteCode);
 }

--- a/src/main/java/com/moa/moa_server/domain/group/service/GroupService.java
+++ b/src/main/java/com/moa/moa_server/domain/group/service/GroupService.java
@@ -48,7 +48,7 @@ public class GroupService {
         AuthUserValidator.validateActive(user);
 
         // 초대 코드로 그룹 조회
-        // deletedAt IS NULL 조건을 명시적으로 추가
+        // deletedAt IS NULL 조건은 Group 엔티티의 @Where에서 자동으로 적용됨
         Group group = groupRepository.findByInviteCode(inviteCode)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.INVITE_CODE_NOT_FOUND));
 

--- a/src/main/java/com/moa/moa_server/domain/group/service/GroupService.java
+++ b/src/main/java/com/moa/moa_server/domain/group/service/GroupService.java
@@ -1,20 +1,68 @@
 package com.moa.moa_server.domain.group.service;
 
+import com.moa.moa_server.domain.group.dto.request.GroupJoinRequest;
+import com.moa.moa_server.domain.group.dto.response.GroupJoinResponse;
 import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.entity.GroupMember;
+import com.moa.moa_server.domain.group.handler.GroupErrorCode;
+import com.moa.moa_server.domain.group.handler.GroupException;
+import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
 import com.moa.moa_server.domain.group.repository.GroupRepository;
+import com.moa.moa_server.domain.group.util.GroupValidator;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.handler.UserErrorCode;
+import com.moa.moa_server.domain.user.handler.UserException;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.user.util.AuthUserValidator;
 import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
 import com.moa.moa_server.domain.vote.handler.VoteException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class GroupService {
 
     private final GroupRepository groupRepository;
+    private final UserRepository userRepository;
+    private final GroupMemberRepository groupMemberRepository;
 
     public Group getPublicGroup() {
         return groupRepository.findById(1L)
                 .orElseThrow(() -> new VoteException(VoteErrorCode.GROUP_NOT_FOUND));
+    }
+
+    @Transactional
+    public GroupJoinResponse joinGroup(Long userId, GroupJoinRequest request) {
+        String inviteCode = request.inviteCode().trim().toUpperCase();
+
+        // 초대 코드 형식 검증
+        GroupValidator.validateInviteCode(inviteCode);
+
+        // 공개 그룹은 패스
+
+        // 유저 조회 및 상태 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        AuthUserValidator.validateActive(user);
+
+        // 초대 코드로 그룹 조회
+        Group group = groupRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.INVITE_CODE_NOT_FOUND));
+
+        // 이미 가입 여부 확인 (deletedAt이 null 인지도 체크. null이면 패스. 아래에서 재가입)
+        boolean alreadyJoined = groupMemberRepository.existsByUserAndGroupAndDeletedAtIsNull(user, group);
+        if (alreadyJoined) {
+            throw new GroupException(GroupErrorCode.ALREADY_JOINED);
+        }
+
+        // 그룹 멤버 생성
+        GroupMember member = GroupMember.create(user, group);
+        // 탈퇴 상태였으면 rejoin
+
+        groupMemberRepository.save(member);
+
+        return new GroupJoinResponse(group.getId(), group.getName(), member.getRole().name());
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/group/util/GroupValidator.java
+++ b/src/main/java/com/moa/moa_server/domain/group/util/GroupValidator.java
@@ -1,0 +1,21 @@
+package com.moa.moa_server.domain.group.util;
+
+import com.moa.moa_server.domain.group.handler.GroupErrorCode;
+import com.moa.moa_server.domain.group.handler.GroupException;
+
+import java.util.regex.Pattern;
+
+public class GroupValidator {
+
+    private static final Pattern INVITE_CODE_PATTERN = Pattern.compile("^[A-Z0-9]{6,8}$");
+
+    private GroupValidator() {
+        throw new AssertionError("유틸 클래스는 인스턴스화할 수 없습니다.");
+    }
+
+    public static void validateInviteCode(String inviteCode) {
+        if (inviteCode == null || !INVITE_CODE_PATTERN.matcher(inviteCode).matches()) {
+            throw new GroupException(GroupErrorCode.INVALID_CODE_FORMAT);
+        }
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -122,8 +122,7 @@ public class VoteService {
         Group group = vote.getGroup();
         if (!group.isPublicGroup()) {
             boolean isGroupMember = groupMemberRepository
-                    .findByGroupAndUserIncludingDeleted(group, user)
-                    .filter(m -> m.getDeletedAt() == null)
+                    .findByGroupAndUser(group, user)
                     .isPresent();
 
             if (!isGroupMember) {
@@ -364,8 +363,7 @@ public class VoteService {
         if (group.isPublicGroup()) return null;
 
         return groupMemberRepository
-                .findByGroupAndUserIncludingDeleted(group, user)
-                .filter(GroupMember::isActive)
+                .findByGroupAndUser(group, user)
                 .orElseThrow(() -> new VoteException(VoteErrorCode.NOT_GROUP_MEMBER));
     }
 
@@ -415,8 +413,7 @@ public class VoteService {
                     .orElseThrow(() -> new VoteException(VoteErrorCode.GROUP_NOT_FOUND));
 
             if (!group.isPublicGroup()) {
-                groupMemberRepository.findByGroupAndUserIncludingDeleted(group, user)
-                        .filter(GroupMember::isActive)
+                groupMemberRepository.findByGroupAndUser(group, user)
                         .orElseThrow(() -> new VoteException(VoteErrorCode.FORBIDDEN));
             }
 


### PR DESCRIPTION
## 📌 관련 이슈

- #51 

## 🔥 작업 개요

- 그룹 가입 API 구현

## 🛠️ 작업 상세

- 그룹 가입 API 구현 (`GET /api/v1/groups/join`)
    - 초대 코드 기반 그룹 가입
        - 초대 코드 유효성 검사 (`GroupValidator.validateInviteCode`)
    - 가입 이력에 따른 처리
        - 가입 이력 없으면 새로 생성
        - 탈퇴 이력이 있으면 복구 (soft delete 복원)
        - 이미 가입된 경우 예외 처리
    - 공개 그룹은 가입 불가 처리  

## 🧪 테스트

- [x] 주요 API 수동 테스트 완료
    - 성공 케이스
        - 초대 코드로 신규 그룹 가입
        - 소문자로 초대 코드 전송 → 정상 가입 처리
        - 탈퇴한 그룹 재가입 처리 (soft delete 복구)
    - 실패 케이스
        - 초대 코드가 없거나 형식 오류인 경우 (null, 빈 문자열, 6자 미만, 8자 초과, 영어/숫자 이외 문자 포함)
        - 초대 코드에 해당하는 그룹이 없는 경우
        - 공개 그룹 가입 시도
        - 이미 가입된 경우
- [x] DB 연동 동작 확인 (엔티티 저장, 삭제, 갱신 등)
- [x] 의도한 비즈니스 로직 흐름 정상 동작 확인 (e.g. 중복 방지, 조건 분기 등)
- [x] 서버 로그 및 예외 로그 확인 완료

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
