### PR TITLE
[Feat] 새 그룹 생성 API 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.mysql:mysql-connector-j'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	implementation 'org.apache.commons:commons-lang3:3.12.0'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/moa/moa_server/domain/group/controller/GroupController.java
+++ b/src/main/java/com/moa/moa_server/domain/group/controller/GroupController.java
@@ -1,10 +1,11 @@
 package com.moa.moa_server.domain.group.controller;
 
 import com.moa.moa_server.domain.global.dto.ApiResponse;
+import com.moa.moa_server.domain.group.dto.request.GroupCreateRequest;
 import com.moa.moa_server.domain.group.dto.request.GroupJoinRequest;
+import com.moa.moa_server.domain.group.dto.response.GroupCreateResponse;
 import com.moa.moa_server.domain.group.dto.response.GroupJoinResponse;
 import com.moa.moa_server.domain.group.service.GroupService;
-import com.moa.moa_server.domain.vote.dto.request.VoteCreateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -26,6 +27,17 @@ public class GroupController {
             @RequestBody GroupJoinRequest request
     ) {
         GroupJoinResponse response = groupService.joinGroup(userId, request);
+        return ResponseEntity
+                .status(201)
+                .body(new ApiResponse("SUCCESS", response));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse> createGroup(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody GroupCreateRequest request
+    ) {
+        GroupCreateResponse response = groupService.createGroup(userId, request);
         return ResponseEntity
                 .status(201)
                 .body(new ApiResponse("SUCCESS", response));

--- a/src/main/java/com/moa/moa_server/domain/group/dto/request/GroupCreateRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/group/dto/request/GroupCreateRequest.java
@@ -1,0 +1,7 @@
+package com.moa.moa_server.domain.group.dto.request;
+
+public record GroupCreateRequest(
+        String name,
+        String description,
+        String imageUrl
+) {}

--- a/src/main/java/com/moa/moa_server/domain/group/dto/response/GroupCreateResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/group/dto/response/GroupCreateResponse.java
@@ -1,0 +1,12 @@
+package com.moa.moa_server.domain.group.dto.response;
+
+import java.time.LocalDateTime;
+
+public record GroupCreateResponse(
+        Long groupId,
+        String name,
+        String description,
+        String imageUrl,
+        String inviteCode,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
+++ b/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
@@ -44,11 +44,12 @@ public class Group extends BaseTimeEntity {
     @Column(name = "deleted_at")
     private java.time.LocalDateTime deletedAt;
 
-    public static Group create(User user, String name, String description, String inviteCode) {
+    public static Group create(User user, String name, String description, String imageUrl, String inviteCode) {
         return Group.builder()
                 .user(user)
                 .name(name)
                 .description(description)
+                .imageUrl(imageUrl)
                 .inviteCode(inviteCode)
                 .build();
     }

--- a/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
+++ b/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
@@ -29,7 +29,7 @@ public class Group extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "name", length = 50, nullable = false)
+    @Column(name = "name", length = 50, nullable = false, unique = true)
     private String name;
 
     @Column(name = "description", length = 100, nullable = false)

--- a/src/main/java/com/moa/moa_server/domain/group/entity/GroupMember.java
+++ b/src/main/java/com/moa/moa_server/domain/group/entity/GroupMember.java
@@ -65,4 +65,13 @@ public class GroupMember {
         this.joinedAt = LocalDateTime.now();
         this.role = Role.MEMBER;
     }
+
+    public static GroupMember createAsOwner(User user, Group group) {
+        return GroupMember.builder()
+                .user(user)
+                .group(group)
+                .role(Role.OWNER)
+                .joinedAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
@@ -10,7 +10,8 @@ public enum GroupErrorCode implements BaseErrorCode {
     ALREADY_JOINED(HttpStatus.CONFLICT),
     CANNOT_JOIN_PUBLIC_GROUP(HttpStatus.BAD_REQUEST),
     INVALID_INPUT(HttpStatus.BAD_REQUEST),
-    INVITE_CODE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR);
+    INVITE_CODE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR),
+    DUPLICATE_NAME(HttpStatus.CONFLICT);
 
     private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
@@ -9,7 +9,8 @@ public enum GroupErrorCode implements BaseErrorCode {
     INVITE_CODE_NOT_FOUND(HttpStatus.NOT_FOUND),
     ALREADY_JOINED(HttpStatus.CONFLICT),
     CANNOT_JOIN_PUBLIC_GROUP(HttpStatus.BAD_REQUEST),
-    INVALID_INPUT(HttpStatus.BAD_REQUEST);
+    INVALID_INPUT(HttpStatus.BAD_REQUEST),
+    INVITE_CODE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
@@ -8,7 +8,8 @@ public enum GroupErrorCode implements BaseErrorCode {
     INVALID_CODE_FORMAT(HttpStatus.BAD_REQUEST),
     INVITE_CODE_NOT_FOUND(HttpStatus.NOT_FOUND),
     ALREADY_JOINED(HttpStatus.CONFLICT),
-    CANNOT_JOIN_PUBLIC_GROUP(HttpStatus.BAD_REQUEST),;
+    CANNOT_JOIN_PUBLIC_GROUP(HttpStatus.BAD_REQUEST),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST);
 
     private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/GroupRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface GroupRepository extends JpaRepository<Group, Long> {
     Optional<Group> findByInviteCode(String inviteCode);
     boolean existsByInviteCode(String inviteCode);
+    boolean existsByName(String groupName);
 }

--- a/src/main/java/com/moa/moa_server/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/GroupRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
     Optional<Group> findByInviteCode(String inviteCode);
+    boolean existsByInviteCode(String inviteCode);
 }

--- a/src/main/java/com/moa/moa_server/domain/group/service/GroupService.java
+++ b/src/main/java/com/moa/moa_server/domain/group/service/GroupService.java
@@ -99,6 +99,11 @@ public class GroupService {
         }
         String imageUrl = request.imageUrl().isBlank() ? null : request.imageUrl().trim();
 
+        // 그룹 이름 중복 검사
+        if (groupRepository.existsByName(request.name())) {
+            throw new GroupException(GroupErrorCode.DUPLICATE_NAME);
+        }
+
         // 초대 코드 생성
         String inviteCode = generateUniqueInviteCode();
 

--- a/src/main/java/com/moa/moa_server/domain/group/util/GroupValidator.java
+++ b/src/main/java/com/moa/moa_server/domain/group/util/GroupValidator.java
@@ -2,6 +2,7 @@ package com.moa.moa_server.domain.group.util;
 
 import com.moa.moa_server.domain.group.handler.GroupErrorCode;
 import com.moa.moa_server.domain.group.handler.GroupException;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.util.regex.Pattern;
 
@@ -9,8 +10,12 @@ public class GroupValidator {
 
     private static final Pattern INVITE_CODE_PATTERN = Pattern.compile("^[A-Z0-9]{6,8}$");
     private static final Pattern NAME_PATTERN = Pattern.compile("^(?![\\d\\s])[가-힣a-zA-Z0-9 ]{2,12}$");
-    private static final Pattern IMAGE_URL_PATTERN = Pattern.compile("^https://file-url/.*");
-    // TODO: IMAGE_URL_PATTERN의 file-url을 추후 실제 업로드 서버 주소 (예: S3 도메인)로 대체(applicaton 파일에 정의)
+    private static String uploadUrlPrefix;
+
+    @Value("${file.upload-url-prefix}")
+    public void setUploadUrlPrefix(String prefix) {
+        GroupValidator.uploadUrlPrefix = prefix + "/group";
+    }
 
     private GroupValidator() {
         throw new AssertionError("유틸 클래스는 인스턴스화할 수 없습니다.");
@@ -36,7 +41,7 @@ public class GroupValidator {
     }
 
     public static void validateImageUrl(String imageUrl) {
-        if (imageUrl != null && !imageUrl.isBlank() && !IMAGE_URL_PATTERN.matcher(imageUrl).matches()) {
+        if (imageUrl != null && !imageUrl.isBlank() && !imageUrl.startsWith(uploadUrlPrefix)) {
             throw new GroupException(GroupErrorCode.INVALID_INPUT);
         }
     }

--- a/src/main/java/com/moa/moa_server/domain/group/util/GroupValidator.java
+++ b/src/main/java/com/moa/moa_server/domain/group/util/GroupValidator.java
@@ -2,7 +2,6 @@ package com.moa.moa_server.domain.group.util;
 
 import com.moa.moa_server.domain.group.handler.GroupErrorCode;
 import com.moa.moa_server.domain.group.handler.GroupException;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.util.regex.Pattern;
 
@@ -10,12 +9,7 @@ public class GroupValidator {
 
     private static final Pattern INVITE_CODE_PATTERN = Pattern.compile("^[A-Z0-9]{6,8}$");
     private static final Pattern NAME_PATTERN = Pattern.compile("^(?![\\d\\s])[가-힣a-zA-Z0-9 ]{2,12}$");
-    private static String uploadUrlPrefix;
-
-    @Value("${file.upload-url-prefix}")
-    public void setUploadUrlPrefix(String prefix) {
-        GroupValidator.uploadUrlPrefix = prefix + "/group";
-    }
+    private static final String UPLOAD_URL_PREFIX = "https://upload-domain/group";
 
     private GroupValidator() {
         throw new AssertionError("유틸 클래스는 인스턴스화할 수 없습니다.");
@@ -41,7 +35,7 @@ public class GroupValidator {
     }
 
     public static void validateImageUrl(String imageUrl) {
-        if (imageUrl != null && !imageUrl.isBlank() && !imageUrl.startsWith(uploadUrlPrefix)) {
+        if (imageUrl != null && !imageUrl.isBlank() && !imageUrl.startsWith(UPLOAD_URL_PREFIX)) {
             throw new GroupException(GroupErrorCode.INVALID_INPUT);
         }
     }

--- a/src/main/java/com/moa/moa_server/domain/group/util/GroupValidator.java
+++ b/src/main/java/com/moa/moa_server/domain/group/util/GroupValidator.java
@@ -8,6 +8,9 @@ import java.util.regex.Pattern;
 public class GroupValidator {
 
     private static final Pattern INVITE_CODE_PATTERN = Pattern.compile("^[A-Z0-9]{6,8}$");
+    private static final Pattern NAME_PATTERN = Pattern.compile("^(?![\\d\\s])[가-힣a-zA-Z0-9 ]{2,12}$");
+    private static final Pattern IMAGE_URL_PATTERN = Pattern.compile("^https://file-url/.*");
+    // TODO: IMAGE_URL_PATTERN의 file-url을 추후 실제 업로드 서버 주소 (예: S3 도메인)로 대체(applicaton 파일에 정의)
 
     private GroupValidator() {
         throw new AssertionError("유틸 클래스는 인스턴스화할 수 없습니다.");
@@ -16,6 +19,25 @@ public class GroupValidator {
     public static void validateInviteCode(String inviteCode) {
         if (inviteCode == null || !INVITE_CODE_PATTERN.matcher(inviteCode).matches()) {
             throw new GroupException(GroupErrorCode.INVALID_CODE_FORMAT);
+        }
+    }
+
+    public static void validateGroupName(String name) {
+        if (name == null || name.isBlank() || !NAME_PATTERN.matcher(name).matches()) {
+            throw new GroupException(GroupErrorCode.INVALID_INPUT);
+        }
+    }
+
+
+    public static void validateDescription(String description) {
+        if (description == null || description.isBlank() || description.length() < 2 || description.length() > 50) {
+            throw new GroupException(GroupErrorCode.INVALID_INPUT);
+        }
+    }
+
+    public static void validateImageUrl(String imageUrl) {
+        if (imageUrl != null && !imageUrl.isBlank() && !IMAGE_URL_PATTERN.matcher(imageUrl).matches()) {
+            throw new GroupException(GroupErrorCode.INVALID_INPUT);
         }
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -79,7 +79,8 @@ public class VoteService {
 
         // 요청 값 유효성 검사
         VoteValidator.validateContent(request.content());
-        VoteValidator.validateUrl(request.imageUrl());
+        VoteValidator.validateImageUrl(request.imageUrl());
+        String imageUrl = request.imageUrl().isBlank() ? null : request.imageUrl();
         VoteValidator.validateClosedAt(request.closedAt());
 
         // Vote 생성 및 저장
@@ -87,7 +88,7 @@ public class VoteService {
                 user,
                 group,
                 request.content(),
-                request.imageUrl(),
+                imageUrl,
                 request.closedAt(),
                 adminVote
         );

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -80,7 +80,7 @@ public class VoteService {
         // 요청 값 유효성 검사
         VoteValidator.validateContent(request.content());
         VoteValidator.validateImageUrl(request.imageUrl());
-        String imageUrl = request.imageUrl().isBlank() ? null : request.imageUrl();
+        String imageUrl = request.imageUrl().isBlank() ? null : request.imageUrl().trim();
         VoteValidator.validateClosedAt(request.closedAt());
 
         // Vote 생성 및 저장

--- a/src/main/java/com/moa/moa_server/domain/vote/util/VoteValidator.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/util/VoteValidator.java
@@ -2,11 +2,18 @@ package com.moa.moa_server.domain.vote.util;
 
 import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
 import com.moa.moa_server.domain.vote.handler.VoteException;
+import org.springframework.beans.factory.annotation.Value;
 
-import java.net.URL;
 import java.time.LocalDateTime;
 
 public class VoteValidator {
+
+    private static String uploadUrlPrefix;
+
+    @Value("${file.upload-url-prefix}")
+    public void setUploadUrlPrefix(String prefix) {
+        VoteValidator.uploadUrlPrefix = prefix + "/vote";
+    }
 
     public static void validateContent(String content) {
         if (content == null || content.isBlank() || content.length() > 255 || content.length() < 2) {
@@ -14,12 +21,10 @@ public class VoteValidator {
         }
     }
 
-    public static void validateUrl(String url) {
-        if (url == null || url.isBlank()) return;
-        try {
-            new URL(url).toURI();
-        } catch (Exception e) {
-            throw new VoteException(VoteErrorCode.INVALID_URL);        }
+    public static void validateImageUrl(String imageUrl) {
+        if (imageUrl != null && !imageUrl.isBlank() && !imageUrl.startsWith(uploadUrlPrefix)) {
+            throw new VoteException(VoteErrorCode.INVALID_URL);
+        }
     }
 
     public static void validateClosedAt(LocalDateTime closedAt) {

--- a/src/main/java/com/moa/moa_server/domain/vote/util/VoteValidator.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/util/VoteValidator.java
@@ -2,18 +2,13 @@ package com.moa.moa_server.domain.vote.util;
 
 import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
 import com.moa.moa_server.domain.vote.handler.VoteException;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.time.LocalDateTime;
 
 public class VoteValidator {
 
-    private static String uploadUrlPrefix;
+    private static final String UPLOAD_URL_PREFIX = "https://upload-domain/vote";
 
-    @Value("${file.upload-url-prefix}")
-    public void setUploadUrlPrefix(String prefix) {
-        VoteValidator.uploadUrlPrefix = prefix + "/vote";
-    }
 
     public static void validateContent(String content) {
         if (content == null || content.isBlank() || content.length() > 255 || content.length() < 2) {
@@ -22,7 +17,7 @@ public class VoteValidator {
     }
 
     public static void validateImageUrl(String imageUrl) {
-        if (imageUrl != null && !imageUrl.isBlank() && !imageUrl.startsWith(uploadUrlPrefix)) {
+        if (imageUrl != null && !imageUrl.isBlank() && !imageUrl.startsWith(UPLOAD_URL_PREFIX)) {
             throw new VoteException(VoteErrorCode.INVALID_URL);
         }
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,3 @@ jwt:
 kakao:
   token-uri: https://kauth.kakao.com/oauth/token
   user-info-uri: https://kapi.kakao.com/v2/user/me
-
-file:
-  upload-url-prefix: https://upload-domain

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,3 +8,6 @@ jwt:
 kakao:
   token-uri: https://kauth.kakao.com/oauth/token
   user-info-uri: https://kapi.kakao.com/v2/user/me
+
+file:
+  upload-url-prefix: https://upload-domain


### PR DESCRIPTION
## 📌 관련 이슈

- #52 

## 🔥 작업 개요

- 새 그룹 생성 API 구현

## 🛠️ 작업 상세

- 새 그룹 생성 API 구현 (`POST /api/v1/groups`)
    - 그룹 이름 중복 검사
    - 입력값 유효성 검사 (이름, 소개, 이미지 URL)
    - 초대 코드 생성 로직 추가
    - 생성자(OWNER) 자동 등록

## 🧪 테스트

- [x] 주요 API 수동 테스트 완료
    - 성공 케이스
        - 새 그룹 정상 생성
        - 초대 코드 자동 생성 및 포함 여부 확인
        - GroupMember에 OWNER 권한으로 저장
        - imageUrl이 빈 문자열일 경우 null로 저장
    - 실패 케이스
        - 유효성 검사 실패
            - 그룹 이름: 길이 제한, 허용 문자 제한
            - 그룹 소개: 길이 제한
            - 이미지 URL: 지정된 업로드 도메인 형식 확인
        - 그룹 이름 중복 시 실패
- [x] DB 연동 동작 확인 (엔티티 저장, 삭제, 갱신 등)
- [x] 의도한 비즈니스 로직 흐름 정상 동작 확인 (e.g. 중복 방지, 조건 분기 등)
- [x] 서버 로그 및 예외 로그 확인 완료

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
