### PR TITLE
[Feat] 회원정보 조회/수정 API 개발

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
@@ -11,7 +11,7 @@ public enum GroupErrorCode implements BaseErrorCode {
     CANNOT_JOIN_PUBLIC_GROUP(HttpStatus.BAD_REQUEST),
     INVALID_INPUT(HttpStatus.BAD_REQUEST),
     INVITE_CODE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR),
-    DUPLICATE_NAME(HttpStatus.CONFLICT);
+    DUPLICATED_NAME(HttpStatus.CONFLICT);
 
     private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/group/service/GroupService.java
+++ b/src/main/java/com/moa/moa_server/domain/group/service/GroupService.java
@@ -101,7 +101,7 @@ public class GroupService {
 
         // 그룹 이름 중복 검사
         if (groupRepository.existsByName(request.name())) {
-            throw new GroupException(GroupErrorCode.DUPLICATE_NAME);
+            throw new GroupException(GroupErrorCode.DUPLICATED_NAME);
         }
 
         // 초대 코드 생성

--- a/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
+++ b/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
@@ -1,17 +1,16 @@
 package com.moa.moa_server.domain.user.controller;
 
 import com.moa.moa_server.domain.global.dto.ApiResponse;
+import com.moa.moa_server.domain.user.dto.request.UserUpdateRequest;
 import com.moa.moa_server.domain.user.dto.response.GroupLabelResponse;
 import com.moa.moa_server.domain.user.dto.response.JoinedGroupResponse;
 import com.moa.moa_server.domain.user.dto.response.UserInfoResponse;
+import com.moa.moa_server.domain.user.dto.response.UserUpdateResponse;
 import com.moa.moa_server.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -45,6 +44,15 @@ public class UserController {
             @AuthenticationPrincipal Long userId
     ) {
         UserInfoResponse response = userService.getUserInfo(userId);
+        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
+    }
+
+    @PatchMapping
+    public ResponseEntity<ApiResponse> updateUserInfo(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody UserUpdateRequest request
+    ) {
+        UserUpdateResponse response = userService.updateUserInfo(userId, request);
         return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
+++ b/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
@@ -3,6 +3,8 @@ package com.moa.moa_server.domain.user.controller;
 import com.moa.moa_server.domain.global.dto.ApiResponse;
 import com.moa.moa_server.domain.user.dto.response.GroupLabelResponse;
 import com.moa.moa_server.domain.user.dto.response.JoinedGroupResponse;
+import com.moa.moa_server.domain.user.dto.response.UserInfoResponse;
+import com.moa.moa_server.domain.user.entity.User;
 import com.moa.moa_server.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -36,6 +38,14 @@ public class UserController {
             @RequestParam(required = false) Integer size
     ) {
         JoinedGroupResponse response = userService.getJoinedGroups(userId, cursor, size);
+        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse> getUserInfo(
+            @AuthenticationPrincipal Long userId
+    ) {
+        UserInfoResponse response = userService.getUserInfo(userId);
         return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
+++ b/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
@@ -4,7 +4,6 @@ import com.moa.moa_server.domain.global.dto.ApiResponse;
 import com.moa.moa_server.domain.user.dto.response.GroupLabelResponse;
 import com.moa.moa_server.domain.user.dto.response.JoinedGroupResponse;
 import com.moa.moa_server.domain.user.dto.response.UserInfoResponse;
-import com.moa.moa_server.domain.user.entity.User;
 import com.moa.moa_server.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/moa/moa_server/domain/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/user/dto/request/UserUpdateRequest.java
@@ -1,0 +1,5 @@
+package com.moa.moa_server.domain.user.dto.request;
+
+public record UserUpdateRequest(
+        String nickname
+) {}

--- a/src/main/java/com/moa/moa_server/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,9 @@
+package com.moa.moa_server.domain.user.dto.response;
+
+public record UserInfoResponse(
+        String nickname
+) {
+    public static UserInfoResponse from(String nickname) {
+        return new UserInfoResponse(nickname);
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/user/dto/response/UserUpdateResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/user/dto/response/UserUpdateResponse.java
@@ -1,0 +1,5 @@
+package com.moa.moa_server.domain.user.dto.response;
+
+public record UserUpdateResponse(
+        String nickname
+) {}

--- a/src/main/java/com/moa/moa_server/domain/user/entity/User.java
+++ b/src/main/java/com/moa/moa_server/domain/user/entity/User.java
@@ -48,4 +48,8 @@ public class User extends BaseTimeEntity {
         WITHDRAWN,
         DORMANT,
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/moa/moa_server/domain/user/handler/UserErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/user/handler/UserErrorCode.java
@@ -8,7 +8,8 @@ public enum UserErrorCode implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND),
     USER_WITHDRAWN(HttpStatus.UNAUTHORIZED),
     INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST),
-    INVALID_NICKNAME(HttpStatus.BAD_REQUEST),;
+    INVALID_NICKNAME(HttpStatus.BAD_REQUEST),
+    DUPLICATED_NICKNAME(HttpStatus.CONFLICT);
 
     private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/user/handler/UserErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/user/handler/UserErrorCode.java
@@ -7,7 +7,8 @@ public enum UserErrorCode implements BaseErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND),
     USER_WITHDRAWN(HttpStatus.UNAUTHORIZED),
-    INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST),;
+    INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST),
+    INVALID_NICKNAME(HttpStatus.BAD_REQUEST),;
 
     private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/user/repository/UserRepository.java
@@ -4,5 +4,5 @@ import com.moa.moa_server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    boolean existsByNicknameAndIdNot(String nickname, Long id);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/moa/moa_server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/user/repository/UserRepository.java
@@ -4,4 +4,5 @@ import com.moa.moa_server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByNicknameAndIdNot(String nickname, Long id);
 }

--- a/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
+++ b/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
@@ -116,14 +116,18 @@ public class UserService {
         // 닉네임 유효성 검사
         UserValidator.validateNickname(newNickname);
 
-        // 닉네임 중복 검사 (자기 자신 제외)
-        if (userRepository.existsByNicknameAndIdNot(newNickname, userId)) {
+        // 동일 닉네임이면 중복 처리 없이 바로 반환
+        if (user.getNickname().equals(newNickname)) {
+            return new UserUpdateResponse(user.getNickname());
+        }
+
+        // 닉네임 중복 검사
+        if (userRepository.existsByNickname(newNickname)) {
             throw new UserException(UserErrorCode.DUPLICATED_NICKNAME);
         }
 
         // 닉네임 변경
         user.updateNickname(newNickname);
-
         return new UserUpdateResponse(newNickname);
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
+++ b/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
@@ -5,10 +5,7 @@ import com.moa.moa_server.domain.group.entity.Group;
 import com.moa.moa_server.domain.group.entity.GroupMember;
 import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
 import com.moa.moa_server.domain.group.service.GroupService;
-import com.moa.moa_server.domain.user.dto.response.GroupDetail;
-import com.moa.moa_server.domain.user.dto.response.GroupLabel;
-import com.moa.moa_server.domain.user.dto.response.GroupLabelResponse;
-import com.moa.moa_server.domain.user.dto.response.JoinedGroupResponse;
+import com.moa.moa_server.domain.user.dto.response.*;
 import com.moa.moa_server.domain.user.entity.User;
 import com.moa.moa_server.domain.user.handler.UserErrorCode;
 import com.moa.moa_server.domain.user.handler.UserException;
@@ -94,5 +91,14 @@ public class UserService {
                 .toList();
 
         return new JoinedGroupResponse(groups, nextCursor, hasNext, groups.size());
+    }
+
+    @Transactional(readOnly = true)
+    public UserInfoResponse getUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        AuthUserValidator.validateActive(user);
+
+        return UserInfoResponse.from(user.getNickname());
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/user/util/UserValidator.java
+++ b/src/main/java/com/moa/moa_server/domain/user/util/UserValidator.java
@@ -1,0 +1,21 @@
+package com.moa.moa_server.domain.user.util;
+
+import com.moa.moa_server.domain.user.handler.UserErrorCode;
+import com.moa.moa_server.domain.user.handler.UserException;
+
+import java.util.regex.Pattern;
+
+public class UserValidator {
+
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^(?![\\d\\s])[가-힣a-zA-Z0-9]{2,10}$");
+
+    private UserValidator() {
+        throw new AssertionError("유틸 클래스는 인스턴스화할 수 없습니다.");
+    }
+
+    public static void validateNickname(String nickname) {
+        if (nickname == null || nickname.isBlank() || !NICKNAME_PATTERN.matcher(nickname).matches()) {
+            throw new UserException(UserErrorCode.INVALID_NICKNAME);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- #53 
- #54 

## 🔥 작업 개요

- 회원정보 조회 API 구현
- 회원정보 수정 API 구현

## 🛠️ 작업 상세

- 회원정보 조회 API 구현 (`GET /api/v1/user`)
- 회원정보 수정 API 구현 (`PATCH /api/v1/user`)
    - 닉네임 유효성 검사
    - 닉네임 중복 검사 (기존 닉네임과 같은 경우는 예외 없이 성공 처리)

## 🧪 테스트

- [x] 주요 API 수동 테스트 완료
    - 회원정보 조회 
    - 회원정보 수정
        - 닉네임 정상 수정
        - 기존과 동일한 닉네임 → 성공
        - 닉네임 유효성 검사 → 실패 시 400
        - 닉네임 중복 검사 → 실패 시 409
- [x] DB 연동 동작 확인 (엔티티 저장, 삭제, 갱신 등)
- [x] 의도한 비즈니스 로직 흐름 정상 동작 확인 (e.g. 중복 방지, 조건 분기 등)
- [x] 서버 로그 및 예외 로그 확인 완료

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
