### PR TITLE
[Feat] 회원 탈퇴 API 개발

### DIFF
--- a/src/main/java/com/moa/moa_server/config/RestTemplateConfig.java
+++ b/src/main/java/com/moa/moa_server/config/RestTemplateConfig.java
@@ -1,11 +1,11 @@
-package com.moa.moa_server.domain.ai.config;
+package com.moa.moa_server.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
-public class AiConfig {
+public class RestTemplateConfig {
 
     @Bean
     public RestTemplate restTemplate() {

--- a/src/main/java/com/moa/moa_server/domain/auth/handler/AuthErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/handler/AuthErrorCode.java
@@ -12,7 +12,8 @@ public enum AuthErrorCode implements BaseErrorCode {
     USER_WITHDRAWN(HttpStatus.UNAUTHORIZED),
     INVALID_PROVIDER(HttpStatus.BAD_REQUEST),
     KAKAO_TOKEN_FAILED(HttpStatus.UNAUTHORIZED),
-    KAKAO_USERINFO_FAILED(HttpStatus.UNAUTHORIZED);
+    KAKAO_USERINFO_FAILED(HttpStatus.UNAUTHORIZED),
+    OAUTH_NOT_FOUND(HttpStatus.NOT_FOUND),;
 
     private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/auth/repository/OAuthRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/repository/OAuthRepository.java
@@ -1,6 +1,7 @@
 package com.moa.moa_server.domain.auth.repository;
 
 import com.moa.moa_server.domain.auth.entity.OAuth;
+import com.moa.moa_server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.lang.NonNull;
 
@@ -10,4 +11,5 @@ public interface OAuthRepository extends JpaRepository<OAuth, Long> {
 
     Optional<OAuth> findById(@NonNull Long id);
     void deleteByUserId(Long userId);
+    Optional<OAuth> findByUser(User user);
 }

--- a/src/main/java/com/moa/moa_server/domain/auth/repository/OAuthRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/repository/OAuthRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface OAuthRepository extends JpaRepository<OAuth, Long> {
 
     Optional<OAuth> findById(@NonNull Long id);
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/moa/moa_server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/service/AuthService.java
@@ -55,4 +55,11 @@ public class AuthService {
     public boolean logout(Long userId) {
         return refreshTokenService.deleteRefreshTokenByUserId(userId); // true면 SUCCESS, false면 ALREADY_LOGGED_OUT
     }
+
+    public void unlinkKakaoAccount(Long kakaoUserId) {
+        OAuthLoginStrategy strategy = strategies.get("kakao");
+        if (strategy != null) {
+            strategy.unlink(kakaoUserId);
+        }
+    }
 }

--- a/src/main/java/com/moa/moa_server/domain/auth/service/strategy/OAuthLoginStrategy.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/service/strategy/OAuthLoginStrategy.java
@@ -4,4 +4,5 @@ import com.moa.moa_server.domain.auth.dto.model.LoginResult;
 
 public interface OAuthLoginStrategy {
     LoginResult login(String code);
+    void unlink(Long oauthId);
 }

--- a/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
+++ b/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
@@ -7,6 +7,8 @@ import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -56,5 +58,13 @@ public class Group extends BaseTimeEntity {
 
     public boolean isPublicGroup() {
         return this.id != null && this.id.equals(PUBLIC_GROUP_ID);
+    }
+
+    public void changeOwner(User newOwner) {
+        this.user = newOwner;
+    }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/group/entity/GroupMember.java
+++ b/src/main/java/com/moa/moa_server/domain/group/entity/GroupMember.java
@@ -74,4 +74,12 @@ public class GroupMember {
                 .joinedAt(LocalDateTime.now())
                 .build();
     }
+
+    public boolean isActiveUser() {
+        return user != null && user.getUserStatus() == User.UserStatus.ACTIVE;
+    }
+
+    public void changeToOwner() {
+        this.role = Role.OWNER;
+    }
 }

--- a/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepository.java
@@ -21,4 +21,6 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>,
 
     @Query("SELECT gm.group FROM GroupMember gm WHERE gm.user = :user AND gm.deletedAt IS NULL")
     List<Group> findAllActiveGroupsByUser(@Param("user") User user);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepository.java
@@ -23,4 +23,6 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>,
     List<Group> findAllActiveGroupsByUser(@Param("user") User user);
 
     void deleteAllByUserId(Long userId);
+
+    List<GroupMember> findAllByGroupOrderByJoinedAtAsc(Group group);
 }

--- a/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepository.java
@@ -4,6 +4,7 @@ import com.moa.moa_server.domain.group.entity.Group;
 import com.moa.moa_server.domain.group.entity.GroupMember;
 import com.moa.moa_server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -23,6 +24,10 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>,
     List<Group> findAllActiveGroupsByUser(@Param("user") User user);
 
     void deleteAllByUserId(Long userId);
+
+    @Modifying
+    @Query("DELETE FROM GroupMember gm WHERE gm.user.id = :userId")
+    void hardDeleteAllByUserId(@Param("userId") Long userId);
 
     List<GroupMember> findAllByGroupOrderByJoinedAtAsc(Group group);
 }

--- a/src/main/java/com/moa/moa_server/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/GroupRepository.java
@@ -1,12 +1,15 @@
 package com.moa.moa_server.domain.group.repository;
 
 import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
     Optional<Group> findByInviteCode(String inviteCode);
     boolean existsByInviteCode(String inviteCode);
     boolean existsByName(String groupName);
+    List<Group> findAllByUser(User user);
 }

--- a/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
+++ b/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
@@ -55,4 +55,12 @@ public class UserController {
         UserUpdateResponse response = userService.updateUserInfo(userId, request);
         return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
     }
+
+    @DeleteMapping
+    public ResponseEntity<ApiResponse> deleteUser(
+            @AuthenticationPrincipal Long userId
+    ) {
+        userService.deleteUser(userId);
+        return ResponseEntity.ok(new ApiResponse("SUCCESS", null));
+    }
 }

--- a/src/main/java/com/moa/moa_server/domain/user/entity/User.java
+++ b/src/main/java/com/moa/moa_server/domain/user/entity/User.java
@@ -52,4 +52,9 @@ public class User extends BaseTimeEntity {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    public void withdraw() {
+        this.userStatus = UserStatus.WITHDRAWN;
+        this.withdrawn_at = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
+++ b/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
@@ -137,7 +137,8 @@ public class UserService {
         return new UserUpdateResponse(newNickname);
     }
 
-    @Transactional void deleteUser(Long userId) {
+    @Transactional
+    public void deleteUser(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
         AuthUserValidator.validateActive(user);

--- a/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
+++ b/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
@@ -152,7 +152,7 @@ public class UserService {
         groupService.reassignOrDeleteGroupsOwnedBy(user);
 
         // 2. 그룹 멤버 삭제 (hard delete)
-        groupMemberRepository.deleteAllByUserId(userId);
+        groupMemberRepository.hardDeleteAllByUserId(userId);
 
         // 3. 유저가 생성한 투표 삭제 (soft delete)
         voteRepository.softDeleteAllByUser(user);

--- a/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
+++ b/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
@@ -162,11 +162,11 @@ public class UserService {
         tokenRepository.deleteByUserId(userId);
         oauthRepository.deleteByUserId(userId);
 
-        // 그룹 멤버 삭제 (hard-delete)
-        groupMemberRepository.deleteAllByUserId(userId);
-
         // 그룹 소유자 승계
-        // groupService.reassignOrDeleteGroupsOwnedBy(user);
+        groupService.reassignOrDeleteGroupsOwnedBy(user);
+
+        // 그룹 멤버 삭제 (hard delete)
+        groupMemberRepository.deleteAllByUserId(userId);
 
         // 유저가 생성한 투표 삭제 (soft delete)
         voteRepository.softDeleteAllByUser(user);

--- a/src/main/java/com/moa/moa_server/domain/vote/repository/VoteRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/repository/VoteRepository.java
@@ -1,7 +1,15 @@
 package com.moa.moa_server.domain.vote.repository;
 
+import com.moa.moa_server.domain.user.entity.User;
 import com.moa.moa_server.domain.vote.entity.Vote;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface VoteRepository extends JpaRepository<Vote, Long>, VoteRepositoryCustom {
+
+    @Modifying
+    @Query("UPDATE Vote v SET v.deletedAt = CURRENT_TIMESTAMP WHERE v.user = :user")
+    void softDeleteAllByUser(@Param("user") User user);
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -14,6 +14,7 @@ spring:
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   redirect-uri: ${FRONTEND_URL}/auth/callback
+  admin-key: ${KAKAO_ADMIN_KEY}
 
 frontend:
   url: ${FRONTEND_URL}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -18,6 +18,7 @@ spring:
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   redirect-uri: http://localhost:8080/api/v1/auth/login/oauth
+  admin-key: ${KAKAO_ADMIN_KEY}
 
 ai:
   server-url: http://localhost:8080/mock-ai

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -14,6 +14,7 @@ spring:
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   redirect-uri: ${FRONTEND_URL}/auth/callback
+  admin-key: ${KAKAO_ADMIN_KEY}
 
 frontend:
   url: ${FRONTEND_URL}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,3 +8,4 @@ jwt:
 kakao:
   token-uri: https://kauth.kakao.com/oauth/token
   user-info-uri: https://kapi.kakao.com/v2/user/me
+  unlink-uri: https://kapi.kakao.com/v1/user/unlink


### PR DESCRIPTION
## 📌 관련 이슈

- #29 

## 🔥 작업 개요

- 회원 탈퇴 API 구현 및 탈퇴 시 관련 데이터 처리

## 🛠️ 작업 상세

- 회원 탈퇴 API 구현 (`DELETE /api/v1/user`)
- 탈퇴 시 처리되는 연관 데이터:
    - Group
        - 사용자가 소유자인 경우, 소유자 승계 (MANAGER → MEMBER 순)
        - 승계 불가능하면 그룹 Soft Delete 처리
    - GroupMember / Token / OAuth
        - 해당 유저 데이터 Hard Delete
    - Vote
        - Soft Delete (deleted_at 설정)
    - VoteResponse
        - 삭제하지 않음 (집계 포함 위함)
- 카카오 소셜 연결 해제 (Admin Key 기반 unlink API 호출)
- 회원 상태 변경 → Soft Delete (user_status = WITHDRAWN, withdrawn_at 설정)
- 예외 처리
    - 이미 탈퇴한 유저가 같은 액세스 토큰으로 재 요청 시 → USER_WITHDRAWN 반환
    - 탈퇴하고 재가입하는 경우, 새로운 user_id로 가입됨 

## 🧪 테스트

- [x] 주요 API 수동 테스트 완료
    - 성공 케이스
        - 회원 soft delete (user_status, withdrawn_at 확인)
        - 그룹 소유자 승계 or 그룹 soft delete
        - GroupMember, Token, OAuth 데이터 삭제
        - Vote soft delete
        - 카카오 unlink API 로그 확인
    - 실패 케이스
        - 이미 탈퇴한 유저가 재요청 시 예외 처리 (USER_WITHDRAWN)
    - 데이터 정합성
        - 탈퇴 유저의 투표는 조회되지 않음
        - 동일한 ID로 재가입 불가 (Unique Constraint 확인)
        - 그룹 소유자 승계 정확히 작동함
- [x] DB 연동 동작 확인 (엔티티 저장, 삭제, 갱신 등)
- [x] 의도한 비즈니스 로직 흐름 정상 동작 확인 (e.g. 중복 방지, 조건 분기 등)
- [x] 서버 로그 및 예외 로그 확인 완료

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
