### PR TITLE
[Feat] 카카오 로그인 시 동적 redirect URI 허용 및 검증 추가

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/controller/AuthController.java
@@ -33,10 +33,11 @@ public class AuthController {
     @PostMapping("/login/oauth")
     public ResponseEntity<ApiResponse> oAuthLogin(
             @RequestBody LoginRequest request,
+            @RequestHeader("X-Redirect-Uri") String redirectUri,
             HttpServletResponse response
     ) {
         // OAuth 로그인 서비스 로직 수행
-        LoginResult dto = authService.login(request.provider(), request.code());
+        LoginResult dto = authService.login(request.provider(), request.code(), redirectUri);
         LoginResponse loginResponseDto = dto.loginResponseDto();
         String refreshToken = dto.refreshToken();
 

--- a/src/main/java/com/moa/moa_server/domain/auth/handler/AuthErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/handler/AuthErrorCode.java
@@ -13,7 +13,8 @@ public enum AuthErrorCode implements BaseErrorCode {
     INVALID_PROVIDER(HttpStatus.BAD_REQUEST),
     KAKAO_TOKEN_FAILED(HttpStatus.UNAUTHORIZED),
     KAKAO_USERINFO_FAILED(HttpStatus.UNAUTHORIZED),
-    OAUTH_NOT_FOUND(HttpStatus.NOT_FOUND),;
+    OAUTH_NOT_FOUND(HttpStatus.NOT_FOUND),
+    INVALID_REDIRECT_URI(HttpStatus.BAD_REQUEST),;
 
     private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/auth/service/strategy/KakaoOAuthLoginStrategy.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/service/strategy/KakaoOAuthLoginStrategy.java
@@ -60,9 +60,9 @@ public class KakaoOAuthLoginStrategy implements OAuthLoginStrategy {
 
     @Transactional
     @Override
-    public LoginResult login(String code) {
+    public LoginResult login(String code, String redirectUri) {
         // 인가코드로 카카오 액세스 토큰 요청
-        String kakaoAccessToken = getAccessToken(code);
+        String kakaoAccessToken = getAccessToken(code, redirectUri);
 
         // 카카오 액세스 토큰으로 사용자 정보 요청
         Long kakaoId = getUserInfo(kakaoAccessToken);
@@ -95,7 +95,7 @@ public class KakaoOAuthLoginStrategy implements OAuthLoginStrategy {
         return new LoginResult(loginResponseDto, refreshToken);
     }
 
-    private String getAccessToken(String code) {
+    private String getAccessToken(String code, String redirectUri) {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
@@ -103,7 +103,7 @@ public class KakaoOAuthLoginStrategy implements OAuthLoginStrategy {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", kakaoClientId);
-        body.add("redirect_uri", kakaoRedirectUri);
+        body.add("redirect_uri", redirectUri);
         body.add("code", code);
 
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);

--- a/src/main/java/com/moa/moa_server/domain/auth/service/strategy/OAuthLoginStrategy.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/service/strategy/OAuthLoginStrategy.java
@@ -3,6 +3,6 @@ package com.moa.moa_server.domain.auth.service.strategy;
 import com.moa.moa_server.domain.auth.dto.model.LoginResult;
 
 public interface OAuthLoginStrategy {
-    LoginResult login(String code);
+    LoginResult login(String code, String redirectUri);
     void unlink(Long oauthId);
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -27,4 +27,5 @@ mock:
 
 logging:
   level:
+    root: INFO
     org.springframework.security: DEBUG


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #66

## 🔥 작업 개요

- 카카오 로그인에서 redirect URI를 요청에 따라 동적으로 처리하도록 개선

## 🛠️ 작업 상세

- 작업 이유: 기존에는 카카오 OAuth 인증 과정에서 Dev 환경의 redirect_uri가 프론트 배포 주소로 고정되어 있어, 로컬 환경에서 Dev 서버로의 로그인 테스트가 불가능했습니다. 이를 해결하기 위해 요청 헤더로 redirect URI를 받아 처리하도록 개선하였습니다.
- 카카오 로그인에서 redirect URI를 요청에 따라 동적으로 처리하도록 개선
   - 프론트에서 전달한 X-Redirect-Uri 헤더를 통해 redirect URI를 받도록 변경
   - Kakao 토큰 요청 시 redirect_uri를 고정값이 아닌 동적 값으로 설정
   - 허용된 redirect URI 목록을 서버에서 검증하여 보안 강화
   - 허용되지 않은 URI 요청 시 AuthException 발생 및 에러 로그 출력

## 🧪 테스트

- [x] 주요 API 수동 테스트 완료
- [x] 서버 로그 및 예외 로그 확인 완료
    - 허용되지 않은 URI 요청 시 AuthException 발생 및 에러 로그 출력

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
