### PR TITLE
[Feat] AI 기반 투표 내용 검열 기능 추가

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/ai/controller/AiController.java
+++ b/src/main/java/com/moa/moa_server/domain/ai/controller/AiController.java
@@ -11,8 +11,8 @@ public class AiController {
 
     // AI 검열 결과 수신용
     // `/api/v1/ai/votes/moderation/callback`
-    @PostMapping("/votes/moderation/callback")
-    public ResponseEntity<String> aiVotesTest() {
-        return ResponseEntity.ok("AI vote received (mock)");
-    }
+//    @PostMapping("/votes/moderation/callback")
+//    public ResponseEntity<String> aiVotesTest() {
+//        return ResponseEntity.ok("AI vote received (mock)");
+//    }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteModerationController.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteModerationController.java
@@ -1,0 +1,30 @@
+package com.moa.moa_server.domain.vote.controller;
+
+import com.moa.moa_server.domain.global.dto.ApiResponse;
+import com.moa.moa_server.domain.vote.dto.moderation.VoteModerationCallbackRequest;
+import com.moa.moa_server.domain.vote.dto.moderation.VoteModerationCallbackResponse;
+import com.moa.moa_server.domain.vote.service.VoteModerationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/ai")
+public class VoteModerationController {
+
+    private final VoteModerationService voteModerationService;
+
+    @PostMapping("/votes/moderation/callback")
+    public ResponseEntity<ApiResponse> callback(
+            @RequestBody VoteModerationCallbackRequest request
+    ) {
+        VoteModerationCallbackResponse result = voteModerationService.handleCallback(request);
+        return ResponseEntity
+                .status(201)
+                .body(new ApiResponse("SUCCESS", result));
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/moderation/VoteModerationCallbackRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/moderation/VoteModerationCallbackRequest.java
@@ -1,0 +1,9 @@
+package com.moa.moa_server.domain.vote.dto.moderation;
+
+public record VoteModerationCallbackRequest(
+        Long voteId,
+        String result,
+        String reason,
+        String reasonDetail,
+        String version
+) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/moderation/VoteModerationCallbackResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/moderation/VoteModerationCallbackResponse.java
@@ -1,0 +1,6 @@
+package com.moa.moa_server.domain.vote.dto.moderation;
+
+public record VoteModerationCallbackResponse(
+        Long voteId,
+        boolean stored
+) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/moderation/VoteModerationRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/moderation/VoteModerationRequest.java
@@ -1,0 +1,6 @@
+package com.moa.moa_server.domain.vote.dto.moderation;
+
+public record VoteModerationRequest(
+        Long voteId,
+        String content
+) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
@@ -93,4 +93,8 @@ public class Vote extends BaseTimeEntity {
     public boolean isOpen() {
         return this.voteStatus == VoteStatus.OPEN;
     }
+
+    public void updateModerationResult(VoteStatus voteStatus) {
+        this.voteStatus = voteStatus;
+    }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
@@ -83,7 +83,7 @@ public class Vote extends BaseTimeEntity {
                 .imageUrl(imageUrl)
                 .closedAt(closedAt)
                 .anonymous(false) // TODO: 익명 기능 추가 시, 요청값으로 변경
-                .voteStatus(VoteStatus.OPEN) // TODO: 투표 검열 기능 추가 시, PENDING 으로 변경
+                .voteStatus(VoteStatus.PENDING) // TODO: 투표 검열 기능 추가 시, PENDING 으로 변경
                 .adminVote(adminVote)
                 .voteType(VoteType.USER)
                 .lastAnonymousNumber(0)

--- a/src/main/java/com/moa/moa_server/domain/vote/handler/VoteErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/handler/VoteErrorCode.java
@@ -15,7 +15,8 @@ public enum VoteErrorCode implements BaseErrorCode {
     INVALID_OPTION(HttpStatus.BAD_REQUEST),
     ALREADY_VOTED(HttpStatus.CONFLICT),
     VOTE_NOT_OPENED(HttpStatus.FORBIDDEN),
-    INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST),;
+    INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST),
+    INVALID_MODERATION_RESULT(HttpStatus.BAD_REQUEST),;
 
     private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteModerationService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteModerationService.java
@@ -1,0 +1,81 @@
+package com.moa.moa_server.domain.vote.service;
+
+import com.moa.moa_server.domain.vote.dto.moderation.VoteModerationCallbackRequest;
+import com.moa.moa_server.domain.vote.dto.moderation.VoteModerationCallbackResponse;
+import com.moa.moa_server.domain.vote.dto.moderation.VoteModerationRequest;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.entity.VoteModerationLog;
+import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
+import com.moa.moa_server.domain.vote.handler.VoteException;
+import com.moa.moa_server.domain.vote.repository.VoteModerationLogRepository;
+import com.moa.moa_server.domain.vote.repository.VoteRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class VoteModerationService {
+
+    @Value("${ai.server-url}")
+    private String aiServerUrl;
+
+    private final VoteRepository voteRepository;
+    private final VoteModerationLogRepository moderationLogRepository;
+
+    private final RestTemplate restTemplate;
+
+    public void requestModeration(Long voteId, String content) {
+        String moderationUrl = aiServerUrl + "/api/v1/moderation";
+
+        VoteModerationRequest request = new VoteModerationRequest(voteId, content);
+
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(
+                    moderationUrl,
+                    request,
+                    String.class
+            );
+
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                log.warn("[VoteModerationService#requestModeration] Moderation 요청 실패: status: {}, body: {}", response.getStatusCode(), response.getBody());
+            } else {
+                log.info("[VoteModerationService#requestModeration] Moderation 요청 성공: voteId: {}", voteId);
+            }
+
+        } catch (Exception e) {
+            log.error("[VoteModerationService#requestModeration] Moderation 요청 중 예외 발생: voteId: {}, error: {}", voteId, e.getMessage(), e);
+        }
+    }
+
+    @Transactional
+    public VoteModerationCallbackResponse handleCallback(VoteModerationCallbackRequest request) {
+//        Vote vote = voteRepository.findById(request.voteId())
+//                .orElseThrow(() -> new VoteException(VoteErrorCode.VOTE_NOT_FOUND));
+//
+//        // result enum 매핑
+//        Vote.VoteStatus status = Vote.VoteStatus.valueOf(request.result().toUpperCase());
+//        ModerationRejectReason reason = ModerationRejectReason.valueOf(request.reason().toUpperCase());
+//
+//        // 상태 반영
+//        vote.updateModerationResult(status);
+//
+//        // 로그 저장
+//        VoteModerationLog log = VoteModerationLog.of(
+//                vote,
+//                status,
+//                reason,
+//                request.reasonDetail(),
+//                request.version()
+//        );
+//        moderationLogRepository.save(log);
+//
+//        return new VoteModerationResult(vote.getId(), true);
+        return null;
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -56,6 +56,7 @@ public class VoteService {
 
     private final GroupService groupService;
     private final VoteResultService voteResultService;
+    private final VoteModerationService voteModerationService;
 
     @Transactional
     public Long createVote(Long userId, VoteCreateRequest request) {
@@ -92,8 +93,10 @@ public class VoteService {
                 request.closedAt(),
                 adminVote
         );
-
         voteRepository.save(vote);
+
+        // AI 서버로 검열 요청
+        voteModerationService.requestModeration(vote.getId(), vote.getContent());
 
         return vote.getId();
     }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -21,7 +21,7 @@ kakao:
   admin-key: ${KAKAO_ADMIN_KEY}
 
 ai:
-  server-url: http://localhost:8080/mock-ai
+  server-url: ${AI_SERVER_URL}
 mock:
   ai:
     enabled: true


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #68 

## 🔥 작업 개요

AI 기반 콘텐츠 검열 기능을 추가하여, 사용자가 생성한 투표 내용에 대해 부적절한 내용을 사전에 필터링할 수 있도록 구현하였습니다.
- 투표 등록 시
    - AI 서버로 검열 요청 전송
    - 투표 상태를 PENDING으로 설정하고, 작성자 외에는 미공개 처리
- AI 서버 콜백 시
    - 검열 결과를 저장하고, 투표 상태를 OPEN 또는 REJECTED로 변경

## 🛠️ 작업 상세

- 투표 등록 시 검열 요청 API 호출 및 PENDING 상태 설정
- AI 서버 콜백 API 구현 및 상태 업데이트 처리
- 검열 결과 저장 로직 추가
- AI 서버 요청 결과 로그 출력

## 🧪 테스트

- [x]  주요 API 수동 테스트 완료
    - AI 서버로 정상 요청
    - 투표 상태 저장 확인
    - 
- []  DB 연동 동작 확인 (엔티티 저장, 삭제, 갱신 등)
- [x]  의도한 비즈니스 로직 흐름 정상 동작 확인 (e.g. 중복 방지, 조건 분기 등)
- [x]  서버 로그 및 예외 로그 확인 완료

## 💬 기타 논의 사항

- 테스트
   - 투표 등록 시, AI 서버로 검열 요청 및 투표 등록 확인 완료.
   - Dev 브랜치 머지 후, AI 서버 콜백 동작 테스트 예정.
- 구현
   - 현재는 단순 콜백 구조이나, 비동기 큐 기반 확장 가능성 고려

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
