### PR TITLE
[Feat] 사용자 피드백 등록 API 개발

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/moa/moa_server/domain/feedback/controller/FeedbackController.java
@@ -1,0 +1,31 @@
+package com.moa.moa_server.domain.feedback.controller;
+
+import com.moa.moa_server.domain.feedback.dto.request.FeedbackCreateRequest;
+import com.moa.moa_server.domain.feedback.service.FeedbackService;
+import com.moa.moa_server.domain.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user-feedback")
+public class FeedbackController {
+
+    private final FeedbackService feedbackService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse> createFeedback(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody FeedbackCreateRequest request
+    ) {
+        feedbackService.createFeedback(userId, request);
+        return ResponseEntity
+                .status(201)
+                .body(new ApiResponse("SUCCESS", null));
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/feedback/dto/request/FeedbackCreateRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/feedback/dto/request/FeedbackCreateRequest.java
@@ -1,0 +1,5 @@
+package com.moa.moa_server.domain.feedback.dto.request;
+
+public record FeedbackCreateRequest (
+        String content
+) {}

--- a/src/main/java/com/moa/moa_server/domain/feedback/entity/Feedback.java
+++ b/src/main/java/com/moa/moa_server/domain/feedback/entity/Feedback.java
@@ -1,0 +1,26 @@
+package com.moa.moa_server.domain.feedback.entity;
+
+import com.moa.moa_server.domain.global.entity.BaseTimeEntity;
+import com.moa.moa_server.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Feedback extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(length = 500, nullable = false)
+    private String content;
+}

--- a/src/main/java/com/moa/moa_server/domain/feedback/entity/Feedback.java
+++ b/src/main/java/com/moa/moa_server/domain/feedback/entity/Feedback.java
@@ -23,4 +23,11 @@ public class Feedback extends BaseTimeEntity {
 
     @Column(length = 500, nullable = false)
     private String content;
+
+    public static Feedback create(User user, String content) {
+        return Feedback.builder()
+                .user(user)
+                .content(content)
+                .build();
+    }
 }

--- a/src/main/java/com/moa/moa_server/domain/feedback/handler/FeedbackErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/feedback/handler/FeedbackErrorCode.java
@@ -1,0 +1,15 @@
+package com.moa.moa_server.domain.feedback.handler;
+
+import com.moa.moa_server.domain.global.exception.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum FeedbackErrorCode implements BaseErrorCode {
+    INVALID_INPUT(HttpStatus.BAD_REQUEST);
+
+    private final HttpStatus status;
+
+    FeedbackErrorCode(HttpStatus status) { this.status = status; }
+
+    public HttpStatus getStatus() { return status; }
+
+}

--- a/src/main/java/com/moa/moa_server/domain/feedback/handler/FeedbackException.java
+++ b/src/main/java/com/moa/moa_server/domain/feedback/handler/FeedbackException.java
@@ -1,0 +1,8 @@
+package com.moa.moa_server.domain.feedback.handler;
+
+import com.moa.moa_server.domain.global.exception.BaseErrorCode;
+import com.moa.moa_server.domain.global.exception.BaseException;
+
+public class FeedbackException extends BaseException {
+    public FeedbackException(BaseErrorCode errorCode) { super(errorCode); }
+}

--- a/src/main/java/com/moa/moa_server/domain/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/feedback/repository/FeedbackRepository.java
@@ -1,0 +1,7 @@
+package com.moa.moa_server.domain.feedback.repository;
+
+import com.moa.moa_server.domain.feedback.entity.Feedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+}

--- a/src/main/java/com/moa/moa_server/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/moa/moa_server/domain/feedback/service/FeedbackService.java
@@ -3,6 +3,7 @@ package com.moa.moa_server.domain.feedback.service;
 import com.moa.moa_server.domain.feedback.dto.request.FeedbackCreateRequest;
 import com.moa.moa_server.domain.feedback.entity.Feedback;
 import com.moa.moa_server.domain.feedback.repository.FeedbackRepository;
+import com.moa.moa_server.domain.feedback.util.FeedbackValidator;
 import com.moa.moa_server.domain.user.entity.User;
 import com.moa.moa_server.domain.user.handler.UserErrorCode;
 import com.moa.moa_server.domain.user.handler.UserException;
@@ -25,6 +26,9 @@ public class FeedbackService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
         AuthUserValidator.validateActive(user);
+
+        //
+        FeedbackValidator.validateContent(request.content());
 
         Feedback feedback = Feedback.create(user, request.content());
 

--- a/src/main/java/com/moa/moa_server/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/moa/moa_server/domain/feedback/service/FeedbackService.java
@@ -1,0 +1,33 @@
+package com.moa.moa_server.domain.feedback.service;
+
+import com.moa.moa_server.domain.feedback.dto.request.FeedbackCreateRequest;
+import com.moa.moa_server.domain.feedback.entity.Feedback;
+import com.moa.moa_server.domain.feedback.repository.FeedbackRepository;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.handler.UserErrorCode;
+import com.moa.moa_server.domain.user.handler.UserException;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.user.util.AuthUserValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackService {
+
+    private final FeedbackRepository feedbackRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void createFeedback(Long userId, FeedbackCreateRequest request) {
+        // 유저 조회 및 검증
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        AuthUserValidator.validateActive(user);
+
+        Feedback feedback = Feedback.create(user, request.content());
+
+        feedbackRepository.save(feedback);
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/feedback/util/FeedbackValidator.java
+++ b/src/main/java/com/moa/moa_server/domain/feedback/util/FeedbackValidator.java
@@ -1,0 +1,13 @@
+package com.moa.moa_server.domain.feedback.util;
+
+import com.moa.moa_server.domain.feedback.handler.FeedbackErrorCode;
+import com.moa.moa_server.domain.feedback.handler.FeedbackException;
+
+public class FeedbackValidator {
+
+    public static void validateContent(String content){
+        if (content == null || content.isBlank() || content.length() > 500 || content.length() < 2) {
+            throw new FeedbackException(FeedbackErrorCode.INVALID_INPUT);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #77

## 🔥 작업 개요

- 사용자 피드백 등록 API 개발

## 🛠️ 작업 상세

- 사용자 피드백 등록 API 구현 (`POST /api/v1/user-feedback`)
    - 피드백 내용 유효성 검사(빈 값, 최소/최대 길이 제한) 포함
    - 피드백은 로그인된 사용자와 연동되어 저장됨

## 🧪 테스트

- [x] 주요 API 수동 테스트 완료
    - 성공 케이스
        - 피드백 정상 등록
    - 실패 케이스
        - 빈 문자열 또는 길이 조건 미충족 시 등록 실패
- [x] DB 연동 동작 확인 (엔티티 저장, 삭제, 갱신 등)
- [x] 의도한 비즈니스 로직 흐름 정상 동작 확인 (e.g. 중복 방지, 조건 분기 등)
- [x] 서버 로그 및 예외 로그 확인 완료

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
