### PR TITLE
[Fix] 투표 종료 시각 UTC 저장 및 로컬 환경 처리 개선

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
@@ -75,7 +75,7 @@ public class Vote extends BaseTimeEntity {
     }
 
     public static Vote createUserVote(User user, Group group, String content, String imageUrl,
-                                      LocalDateTime closedAt, boolean anonymous, boolean adminVote) {
+                                      LocalDateTime closedAt, boolean anonymous, VoteStatus status, boolean adminVote) {
         return Vote.builder()
                 .user(user)
                 .group(group)
@@ -83,7 +83,7 @@ public class Vote extends BaseTimeEntity {
                 .imageUrl(imageUrl)
                 .closedAt(closedAt)
                 .anonymous(anonymous)
-                .voteStatus(VoteStatus.PENDING)
+                .voteStatus(status)
                 .adminVote(adminVote)
                 .voteType(VoteType.USER)
                 .lastAnonymousNumber(0)

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -33,10 +33,15 @@ import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
 import com.moa.moa_server.domain.vote.util.VoteValidator;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -44,6 +49,9 @@ import java.util.stream.Stream;
 @Service
 @RequiredArgsConstructor
 public class VoteService {
+
+    @Value("${spring.profiles.active:}")
+    private String activeProfile;
 
     private static final int DEFAULT_PAGE_SIZE = 10;
     private static final int DEFAULT_UNAUTHENTICATED_PAGE_SIZE = 3;
@@ -82,7 +90,10 @@ public class VoteService {
         VoteValidator.validateContent(request.content());
         VoteValidator.validateImageUrl(request.imageUrl());
         String imageUrl = request.imageUrl().isBlank() ? null : request.imageUrl().trim();
-        VoteValidator.validateClosedAt(request.closedAt());
+
+        ZonedDateTime koreaTime = request.closedAt().atZone(ZoneId.of("Asia/Seoul"));
+        LocalDateTime utcTime = koreaTime.withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+        VoteValidator.validateClosedAt(utcTime);
 
         // Vote 생성 및 저장
         Vote vote = Vote.createUserVote(
@@ -90,14 +101,16 @@ public class VoteService {
                 group,
                 request.content(),
                 imageUrl,
-                request.closedAt().minusHours(9),
+                request.closedAt(),
                 request.anonymous(),
                 adminVote
         );
         voteRepository.save(vote);
 
-        // AI 서버로 검열 요청
-        voteModerationService.requestModeration(vote.getId(), vote.getContent());
+        // AI 서버로 검열 요청 (로컬 환경 제외)
+        if (!"local".equals(activeProfile)) {
+            voteModerationService.requestModeration(vote.getId(), vote.getContent());
+        }
 
         return vote.getId();
     }

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -90,7 +90,7 @@ public class VoteService {
                 group,
                 request.content(),
                 imageUrl,
-                request.closedAt(),
+                request.closedAt().minusHours(9),
                 request.anonymous(),
                 adminVote
         );

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -91,9 +91,13 @@ public class VoteService {
         VoteValidator.validateImageUrl(request.imageUrl());
         String imageUrl = request.imageUrl().isBlank() ? null : request.imageUrl().trim();
 
+        // 투표 종료 시간 변환
         ZonedDateTime koreaTime = request.closedAt().atZone(ZoneId.of("Asia/Seoul"));
         LocalDateTime utcTime = koreaTime.withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
         VoteValidator.validateClosedAt(utcTime);
+
+        // VoteStatus 결정
+        Vote.VoteStatus status = "local".equals(activeProfile) ? Vote.VoteStatus.OPEN : Vote.VoteStatus.PENDING;
 
         // Vote 생성 및 저장
         Vote vote = Vote.createUserVote(
@@ -103,6 +107,7 @@ public class VoteService {
                 imageUrl,
                 request.closedAt(),
                 request.anonymous(),
+                status,
                 adminVote
         );
         voteRepository.save(vote);

--- a/src/main/java/com/moa/moa_server/domain/vote/util/VoteValidator.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/util/VoteValidator.java
@@ -4,6 +4,7 @@ import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
 import com.moa.moa_server.domain.vote.handler.VoteException;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 public class VoteValidator {
 
@@ -23,7 +24,7 @@ public class VoteValidator {
     }
 
     public static void validateClosedAt(LocalDateTime closedAt) {
-        if (closedAt == null || !closedAt.isAfter(LocalDateTime.now())) {
+        if (closedAt == null || !closedAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
             throw new VoteException(VoteErrorCode.INVALID_TIME);        }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #79 

## 🔥 작업 개요

- 투표 종료 시각(ClosedAt)을 KST에서 UTC로 변환하여 저장하도록 수정
- 로컬 환경에서는 검열 로직 생략 및 VoteStatus를 기본값 OPEN으로 설정

## 🛠️ 작업 상세

- VoteService#createVote 내 closedAt 값을 Asia/Seoul → UTC로 변환
- VoteValidator.validateClosedAt()도 UTC 기준으로 시간 검증
- 로컬 환경(spring.profiles.active=local)에서는
    - 검열 요청 로직 제외
    - 투표 상태를 OPEN으로 저장
- 기존 데이터베이스에 등록된 투표에 대해 closed_at - 9시간 적용

## 🧪 테스트

- [x] 주요 API 수동 테스트 완료
    - 성공 케이스
        - 정상 등록 및 검열 생략 여부 확인 (로컬/운영 구분)
- [x] DB 연동 동작 확인 (엔티티 저장, 삭제, 갱신 등)
- [x] 의도한 비즈니스 로직 흐름 정상 동작 확인 (e.g. 중복 방지, 조건 분기 등)
- [x] 서버 로그 및 예외 로그 확인 완료

## 💬 기타 논의 사항

- 없음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
