### PR TITLE
[Fix] 투표 상태 응답을 종료 시각 기반으로 계산하도록 수정

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/mine/MyVoteItem.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/mine/MyVoteItem.java
@@ -17,11 +17,12 @@ public record MyVoteItem(
 ) {
 
     public static MyVoteItem from(Vote vote, List<VoteOptionResultWithId> results) {
+        String status = vote.getClosedAt().isAfter(LocalDateTime.now()) ? "OPEN" : "CLOSED";
         return new MyVoteItem(
                 vote.getId(),
                 vote.getGroup().getId(),
                 vote.getContent(),
-                vote.getVoteStatus().name(),
+                status,
                 vote.getCreatedAt(),
                 vote.getClosedAt(),
                 results


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #81 

## 🔥 작업 개요

- 내가 만든 투표 목록 응답에서 voteStatus 필드를 DB의 상태값이 아닌 종료 시각(closedAt)과 현재 시각을 비교하여 동적으로 계산하도록 변경

## 🛠️ 작업 상세

- MyVoteItem.from(...) 내부 로직 수정
     - vote.getVoteStatus().name() 대신 vote.getClosedAt().isAfter(LocalDateTime.now()) 기준으로 상태("OPEN" / "CLOSED") 결정
- 실제 종료된 투표가 OPEN으로 표시되는 문제 해결

## 🧪 테스트

- [x] 주요 API 수동 테스트 완료
    - 내가 만든 투표 목록 조회 시 종료된 투표가 CLOSED로 정상 반환됨
- [x] DB 연동 동작 확인 (엔티티 저장, 삭제, 갱신 등)
- [x] 의도한 비즈니스 로직 흐름 정상 동작 확인 (e.g. 중복 방지, 조건 분기 등)
- [x] 서버 로그 및 예외 로그 확인 완료

## 💬 기타 논의 사항

- 백그라운드 스케줄러 도입 이후에도 정확성을 위해 status 대신 지금 방식 그대로 closedAt을 사용할 것 같음

### ✅ 셀프 체크리스트

- [x] PR 제목은 형식에 맞게 작성했나요?
- [x] 이슈는 close 됬나요?
- [x] Reviewers, Label을 등록 했나요?
- [x] 불필요한 코드는 제거 했나요?
