### PR TITLE
[Fix] #81 병합 후 REJECTED, PENDING 상태 반영 누락 수정

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/mine/MyVoteItem.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/mine/MyVoteItem.java
@@ -17,7 +17,13 @@ public record MyVoteItem(
 ) {
 
     public static MyVoteItem from(Vote vote, List<VoteOptionResultWithId> results) {
-        String status = vote.getClosedAt().isAfter(LocalDateTime.now()) ? "OPEN" : "CLOSED";
+        String status;
+        if (vote.getVoteStatus() == Vote.VoteStatus.REJECTED || vote.getVoteStatus() == Vote.VoteStatus.PENDING) {
+            status = vote.getVoteStatus().name();
+        } else {
+            status = vote.getClosedAt().isAfter(LocalDateTime.now()) ? "OPEN" : "CLOSED";
+        }
+
         return new MyVoteItem(
                 vote.getId(),
                 vote.getGroup().getId(),

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/mine/MyVoteItem.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/mine/MyVoteItem.java
@@ -17,11 +17,12 @@ public record MyVoteItem(
 ) {
 
     public static MyVoteItem from(Vote vote, List<VoteOptionResultWithId> results) {
+        String status = vote.getClosedAt().isAfter(LocalDateTime.now()) ? "OPEN" : "CLOSED";
         return new MyVoteItem(
                 vote.getId(),
                 vote.getGroup().getId(),
                 vote.getContent(),
-                vote.getVoteStatus().name(),
+                status,
                 vote.getCreatedAt(),
                 vote.getClosedAt(),
                 results


### PR DESCRIPTION
## 📌 관련 이슈
- 후속 작업: #81

## 🔥 작업 개요
- #81 병합 이후 상태 판단 로직에 REJECTED, PENDING 예외 처리가 누락되어 추가 반영

## 🛠️ 작업 상세
- 투표 상태 판단 시 REJECTED, PENDING은 voteStatus 값을 그대로 사용

## 🧪 테스트
- 수동 테스트 완료: 상태별 출력 정상 확인

## ✅ 체크리스트
- [x] 병합 시 충돌 없음
- [x] 기존 기능 영향 없음