### PR TITLE
[Fix] Vote 종료 시각 UTC 저장 누락 수정

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -105,7 +105,7 @@ public class VoteService {
                 group,
                 request.content(),
                 imageUrl,
-                request.closedAt(),
+                utcTime,
                 request.anonymous(),
                 status,
                 adminVote


### PR DESCRIPTION
## 📌 관련 이슈
- 재수정: 기존 PR(#79)에서 UTC 변환 후 해당 값을 사용하지 않고 원본 KST 값을 저장하던 문제 수정

## 🔥 작업 개요
- `VoteService#createVote` 메서드 내 `closedAt` 필드 저장 시 `utcTime`을 사용하도록 수정

## 🛠️ 작업 상세
- 기존에는 변환한 `utcTime`을 검증에만 사용하고, 저장에는 `request.closedAt()`을 그대로 사용했음
- 저장 로직에 `utcTime`이 반영되도록 수정

## 🧪 테스트
- [x] 로컬 환경 포스트맨 테스트 완료
- [] FE에서 보낸 KST 시간 → 서버에서 UTC로 저장되는지 확인 예정

## 💬 기타 논의 사항
- 기존 PR 병합 이후 발견된 이슈로, 후속 조치 PR입니다
- Dev 반영 후, 실제 프론트엔드 요청이 잘 저장되는지 확인 필요