### PR TITLE
cicd: pre-push 트리거 build test script 작성

### DIFF
--- a/.github/scripts/install-hooks.sh
+++ b/.github/scripts/install-hooks.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# sh .github/scripts/install-hooks.sh 명령어로 실행하시면 됩니다. 
+cp .github/scripts/pre-push-build.sh .git/hooks/pre-push
+chmod +x .git/hooks/pre-push
+echo "pre-push hook 설치 완료!"

--- a/.github/scripts/pre-push-build.sh
+++ b/.github/scripts/pre-push-build.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+echo "현재 브랜치: $BRANCH"
+
+if [ "$BRANCH" = "develop" ]; then
+  echo "develop 브랜치 빌드 검사 시작 (spring.profiles.active=dev)..."
+
+  ./gradlew clean build -x test -Dspring.profiles.active=dev
+  if [ $? -ne 0 ]; then
+    echo "빌드 실패! push 차단"
+    exit 1
+  fi
+
+  echo "빌드 성공! push 진행."
+else
+  echo "$BRANCH 브랜치는 빌드 체크 없이 push 허용"
+fi
+
+exit 0


### PR DESCRIPTION
## 개요
develop 브랜치의 push가 허용됨에 따라 push 하기 전 dev 프로필을 사용해 build test를 진행하는 스크립트 작성

## 변경 내용
- `.github/scripts/` 추가
  - 대상 브랜치: `develop`
  - pre-push-build.sh: develop 브랜치에 한해 push 시 build 성공 여부 체크, 빌드 에러 발생 시 push 막힘
  - install-hooks: pre-push-build 스크립트를 pre-push 트리거 설정하기 위한 최초 설정 명령어 모음

## 적용 배경
- 사소한 빌드 에러로 CI/CD 워크플로우가 실패하는 것을 막기 위해 도입
- 빌드 에러 유무를 사전에 명확히 하여 협업 효율을 높이고자 함

## 참고
- 로컬에서 현재 dev 프로필을 사용해 build가 가능한지 확인 바람
- 최초 1회 `sh .github/scripts/install-hooks.sh` 명령어를 통해 hook 설치 필수