### PR TITLE
feat: Swagger(springdoc) 기반 API 명세 자동화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 
 	// Swagger 의존성
 	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8"
+
+	implementation "org.apache.httpcomponents.client5:httpclient5:5.4.4"
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 //	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 //	testImplementation 'jakarta.persistence:jakarta.persistence-api'
 //	testImplementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+
+	// Swagger 의존성
+	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/moa/moa_server/config/RestTemplateConfig.java
+++ b/src/main/java/com/moa/moa_server/config/RestTemplateConfig.java
@@ -2,6 +2,7 @@ package com.moa.moa_server.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -9,6 +10,9 @@ public class RestTemplateConfig {
 
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        var factory = new HttpComponentsClientHttpRequestFactory();
+        factory.setConnectTimeout(2000);    // 연결 타임아웃 (2ms)
+        factory.setReadTimeout(3000);       // 응답 대기 타임아웃 (3ms)
+        return new RestTemplate(factory);
     }
 }

--- a/src/main/java/com/moa/moa_server/config/security/SecurityConstants.java
+++ b/src/main/java/com/moa/moa_server/config/security/SecurityConstants.java
@@ -5,6 +5,10 @@ public class SecurityConstants {
             "/api/v1/auth/login/oauth",
             "/api/v1/auth/token/refresh",
             "/api/v1/test/**",
-            "/api/v1/ai/votes/moderation/callback"
+            "/api/v1/ai/votes/moderation/callback",
+            "/swagger-ui/**",
+            "v3/api-docs/**",
+            "/swagger-resources/**",
+            "/webjars/**"
     };
 }

--- a/src/main/java/com/moa/moa_server/config/security/SecurityConstants.java
+++ b/src/main/java/com/moa/moa_server/config/security/SecurityConstants.java
@@ -6,9 +6,10 @@ public class SecurityConstants {
             "/api/v1/auth/token/refresh",
             "/api/v1/test/**",
             "/api/v1/ai/votes/moderation/callback",
-            "/swagger-ui/**",
             "v3/api-docs/**",
             "/swagger-resources/**",
-            "/webjars/**"
+            "/webjars/**",
+            "/_docs-l0c4l-d3v-ui/**",
+            "/_docs-d3v-p0rt4l/**"
     };
 }

--- a/src/main/java/com/moa/moa_server/config/security/SecurityConstants.java
+++ b/src/main/java/com/moa/moa_server/config/security/SecurityConstants.java
@@ -6,10 +6,9 @@ public class SecurityConstants {
             "/api/v1/auth/token/refresh",
             "/api/v1/test/**",
             "/api/v1/ai/votes/moderation/callback",
+            "/swagger-ui/**",
             "v3/api-docs/**",
             "/swagger-resources/**",
-            "/webjars/**",
-            "/_docs-l0c4l-d3v-ui/**",
-            "/_docs-d3v-p0rt4l/**"
+            "/webjars/**"
     };
 }

--- a/src/main/java/com/moa/moa_server/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/moa/moa_server/config/swagger/SwaggerConfig.java
@@ -1,0 +1,32 @@
+package com.moa.moa_server.config.swagger;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "MOA API", version = "v1"),
+        security = @SecurityRequirement(name = "bearer-key")
+)
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .addSecurityItem(new io.swagger.v3.oas.models.security.SecurityRequirement().addList("bearer-key"))
+                .components(new Components()
+                        .addSecuritySchemes("bearer-key",
+                                new io.swagger.v3.oas.models.security.SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        )
+                );
+    }
+}

--- a/src/main/java/com/moa/moa_server/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/moa/moa_server/config/swagger/SwaggerConfig.java
@@ -8,10 +8,12 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
+@Profile({"local", "dev"})
 @Configuration
 @OpenAPIDefinition(
-        info = @Info(title = "MOA API", version = "v1"),
+        info = @Info(title = "MOA API", version = "v1", description = "모아 서비스 API 문서입니다."),
         security = @SecurityRequirement(name = "bearer-key")
 )
 public class SwaggerConfig {

--- a/src/main/java/com/moa/moa_server/domain/ai/client/AiModerationClient.java
+++ b/src/main/java/com/moa/moa_server/domain/ai/client/AiModerationClient.java
@@ -17,8 +17,9 @@ public class AiModerationClient {
     private String aiServerUrl;
 
     public ModerationResponse requestModeration(ModerationRequest request) {
+        String moderationUrl = aiServerUrl + "/api/v1/moderation/test";
+
         try {
-            String moderationUrl = aiServerUrl + "/api/v1/moderation";
             return restTemplate.postForObject(moderationUrl, request, ModerationResponse.class);
         } catch (Exception e) {
             throw new RuntimeException("AI 서버 요청 실패", e);

--- a/src/main/java/com/moa/moa_server/domain/ai/controller/AiController.java
+++ b/src/main/java/com/moa/moa_server/domain/ai/controller/AiController.java
@@ -1,10 +1,12 @@
 package com.moa.moa_server.domain.ai.controller;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden
 @RestController
 @RequestMapping("/api/v1/ai")
 public class AiController {

--- a/src/main/java/com/moa/moa_server/domain/ai/mock/MockAiController.java
+++ b/src/main/java/com/moa/moa_server/domain/ai/mock/MockAiController.java
@@ -1,5 +1,6 @@
 package com.moa.moa_server.domain.ai.mock;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import com.moa.moa_server.domain.ai.dto.ModerationRequest;
 import com.moa.moa_server.domain.ai.dto.ModerationResponse;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden
 @ConditionalOnProperty(name = "mock.ai.enabled", havingValue = "true")
 @RestController
 @RequestMapping("/mock-ai/api/v1")

--- a/src/main/java/com/moa/moa_server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.moa.moa_server.domain.auth.controller;
 
+import com.moa.moa_server.domain.global.swagger.CommonErrorResponses;
 import com.moa.moa_server.domain.auth.dto.model.LoginResult;
 import com.moa.moa_server.domain.auth.dto.request.LoginRequest;
 import com.moa.moa_server.domain.auth.dto.response.LoginResponse;
@@ -8,6 +9,7 @@ import com.moa.moa_server.domain.auth.handler.AuthErrorCode;
 import com.moa.moa_server.domain.auth.handler.AuthException;
 import com.moa.moa_server.domain.auth.service.AuthService;
 import com.moa.moa_server.domain.auth.service.RefreshTokenService;
+import com.moa.moa_server.domain.auth.swagger.LoginResponses;
 import com.moa.moa_server.domain.global.dto.ApiResponse;
 import com.moa.moa_server.domain.global.dto.ApiResponseVoid;
 import com.moa.moa_server.domain.user.entity.User;
@@ -37,6 +39,7 @@ public class AuthController {
     private final UserRepository userRepository;
 
     @Operation(summary = "소셜 로그인")
+    @LoginResponses
     @PostMapping("/login/oauth")
     public ResponseEntity<ApiResponse<LoginResponse>> oAuthLogin(
             @RequestBody LoginRequest request,
@@ -81,6 +84,7 @@ public class AuthController {
                     )
             }
     )
+    @CommonErrorResponses
     @DeleteMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/moa/moa_server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/controller/AuthController.java
@@ -12,6 +12,8 @@ import com.moa.moa_server.domain.global.dto.ApiResponse;
 import com.moa.moa_server.domain.user.entity.User;
 import com.moa.moa_server.domain.user.repository.UserRepository;
 import com.moa.moa_server.domain.user.util.AuthUserValidator;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Auth", description = "인증 도메인 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
@@ -30,6 +33,7 @@ public class AuthController {
 
     private final UserRepository userRepository;
 
+    @Operation(summary = "소셜 로그인")
     @PostMapping("/login/oauth")
     public ResponseEntity<ApiResponse> oAuthLogin(
             @RequestBody LoginRequest request,
@@ -54,6 +58,7 @@ public class AuthController {
         return ResponseEntity.ok(new ApiResponse("SUCCESS", loginResponseDto));
     }
 
+    @Operation(summary = "토큰 재발급")
     @PostMapping("/token/refresh")
     public ResponseEntity<ApiResponse> refreshAccessToken(HttpServletRequest request) {
         // 쿠키에서 리프레시 토큰 추출
@@ -65,6 +70,7 @@ public class AuthController {
         return ResponseEntity.ok(new ApiResponse("SUCCESS", tokenRefreshResponseDto));
     }
 
+    @Operation(summary = "로그아웃")
     @DeleteMapping("/logout")
     public ResponseEntity<ApiResponse> logout(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/moa/moa_server/domain/auth/dto/model/LoginResult.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/dto/model/LoginResult.java
@@ -1,8 +1,13 @@
 package com.moa.moa_server.domain.auth.dto.model;
 
 import com.moa.moa_server.domain.auth.dto.response.LoginResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "소셜 로그인 서비스 반환 DTO")
 public record LoginResult(
+        @Schema(description = "로그인 응답 DTO")
         LoginResponse loginResponseDto,
+
+        @Schema(description = "리프레시 토큰")
         String refreshToken
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/dto/request/LoginRequest.java
@@ -1,6 +1,12 @@
 package com.moa.moa_server.domain.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "소셜 로그인 요청 DTO")
 public record LoginRequest(
+        @Schema(description = "소셜 로그인 제공자", example = "kakao")
         String provider,
+
+        @Schema(description = "인가 코드", example = "c12o345d678e9")
         String code
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/dto/response/LoginResponse.java
@@ -1,7 +1,16 @@
 package com.moa.moa_server.domain.auth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "소셜 로그인 응답 DTO")
 public record LoginResponse(
+
+        @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6..")
         String accessToken,
+
+        @Schema(description = "사용자 ID", example = "123")
         Long userId,
+
+        @Schema(description = "사용자 닉네임", example = "닉네임")
         String nickname
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/auth/dto/response/TokenRefreshResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/dto/response/TokenRefreshResponse.java
@@ -1,6 +1,13 @@
 package com.moa.moa_server.domain.auth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "토큰 재발급 응답 DTO")
 public record TokenRefreshResponse(
+
+        @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6..")
         String accessToken,
+
+        @Schema(description = "만료 시간", example = "3600")
         int expiresIn
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/auth/swagger/LoginResponses.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/swagger/LoginResponses.java
@@ -1,0 +1,61 @@
+package com.moa.moa_server.domain.auth.swagger;
+
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "Not Found",
+                content = @io.swagger.v3.oas.annotations.media.Content(
+                        mediaType = "application/json",
+                        examples = @ExampleObject(
+                                name = "INVALID_PROVIDER",
+                                description = "지원하지 않는 소셜 로그인 제공자",
+                                value = "{\"message\": \"INVALID_PROVIDER\", \"data\": null}"
+                        )
+                )
+        ),
+        @ApiResponse(responseCode = "401", description = "Unauthorized",
+        content = @io.swagger.v3.oas.annotations.media.Content(
+                mediaType = "application/json",
+                examples = {
+                        @ExampleObject(
+                                name = "KAKAO_TOKEN_FAILED",
+                                description = "카카오 토근 받기 실패",
+                                value = "{\"message\": \"KAKAO_TOKEN_FAILED\", \"data\": null}"
+                        ),
+                        @ExampleObject(
+                                name = "KAKAO_USERINFO_FAILED",
+                                description = "카카오 사용자 정보 받기 실패",
+                                value = "{\"message\": \"KAKAO_USERINFO_FAILED\", \"data\": null}"
+                        )
+                })
+        ),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error",
+                content = @io.swagger.v3.oas.annotations.media.Content(
+                        mediaType = "application/json",
+                        examples = {
+                            @ExampleObject(
+                                    name = "UNEXPECTED_ERROR",
+                                    description = "서버 내부 오류",
+                                    value = "{\"message\": \"UNEXPECTED_ERROR\", \"data\": null}"
+                            ),
+                            @ExampleObject(
+                                    name = "NICKNAME_GENERATION_FAILED",
+                                    description = "닉네임 생성 실패",
+                                    value = "{\"message\": \"NICKNAME_GENERATION_FAILED\", \"data\": null}"
+                            )
+                        }
+                )
+        )
+})
+public @interface LoginResponses {
+}

--- a/src/main/java/com/moa/moa_server/domain/auth/swagger/LoginResponses.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/swagger/LoginResponses.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
                 examples = {
                         @ExampleObject(
                                 name = "KAKAO_TOKEN_FAILED",
-                                description = "카카오 토근 받기 실패",
+                                description = "카카오 토큰 받기 실패",
                                 value = "{\"message\": \"KAKAO_TOKEN_FAILED\", \"data\": null}"
                         ),
                         @ExampleObject(

--- a/src/main/java/com/moa/moa_server/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/moa/moa_server/domain/feedback/controller/FeedbackController.java
@@ -3,7 +3,10 @@ package com.moa.moa_server.domain.feedback.controller;
 import com.moa.moa_server.domain.feedback.dto.request.FeedbackCreateRequest;
 import com.moa.moa_server.domain.feedback.service.FeedbackService;
 import com.moa.moa_server.domain.global.dto.ApiResponse;
+import com.moa.moa_server.domain.global.dto.ApiResponseVoid;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,15 +24,22 @@ public class FeedbackController {
 
     private final FeedbackService feedbackService;
 
-    @Operation(summary = "사용자 피드백 등록")
+    @Operation(summary = "사용자 피드백 등록",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            content = @Content(schema = @Schema(implementation = ApiResponseVoid.class))
+                    )
+            }
+    )
     @PostMapping
-    public ResponseEntity<ApiResponse> createFeedback(
+    public ResponseEntity<ApiResponse<Void>> createFeedback(
             @AuthenticationPrincipal Long userId,
             @RequestBody FeedbackCreateRequest request
     ) {
         feedbackService.createFeedback(userId, request);
         return ResponseEntity
                 .status(201)
-                .body(new ApiResponse("SUCCESS", null));
+                .body(new ApiResponse<>("SUCCESS", null));
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/moa/moa_server/domain/feedback/controller/FeedbackController.java
@@ -3,6 +3,8 @@ package com.moa.moa_server.domain.feedback.controller;
 import com.moa.moa_server.domain.feedback.dto.request.FeedbackCreateRequest;
 import com.moa.moa_server.domain.feedback.service.FeedbackService;
 import com.moa.moa_server.domain.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Feedback", description = "유저 피드백 도메인 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/user-feedback")
@@ -18,6 +21,7 @@ public class FeedbackController {
 
     private final FeedbackService feedbackService;
 
+    @Operation(summary = "사용자 피드백 등록")
     @PostMapping
     public ResponseEntity<ApiResponse> createFeedback(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/moa/moa_server/domain/feedback/dto/request/FeedbackCreateRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/feedback/dto/request/FeedbackCreateRequest.java
@@ -1,5 +1,9 @@
 package com.moa.moa_server.domain.feedback.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자 피드백 등록 요청 DTO")
 public record FeedbackCreateRequest (
+        @Schema(description = "피드백 내용", example = "이러이러한 기능이 있으면 좋겠어요.")
         String content
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/global/controller/TestController.java
+++ b/src/main/java/com/moa/moa_server/domain/global/controller/TestController.java
@@ -3,7 +3,9 @@ package com.moa.moa_server.domain.global.controller;
 import com.moa.moa_server.domain.ai.client.AiModerationClient;
 import com.moa.moa_server.domain.ai.dto.ModerationRequest;
 import com.moa.moa_server.domain.ai.dto.ModerationResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ public class TestController {
     private final AiModerationClient aiModerationClient;
 
     // 누구나 호출 가능한 헬스체크용
+    @Hidden
     @Operation(summary = " 서버 헬스 체크", description = "누구나 호출 가능한 ping API")
     @GetMapping("/ping")
     public ResponseEntity<String> ping() {
@@ -30,7 +33,12 @@ public class TestController {
     }
 
     // AI 서버 연동 테스트
-    @Operation(summary = "AI 서버 연동 테스트", description = "AI 서버에 문장을 보내 검열 결과를 받는 테스트용 API")
+    @Hidden
+    @Operation(summary = "AI 서버 연동 테스트", description = "AI 서버에 문장을 보내 검열 결과를 받는 테스트용 API",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "연동 성공"),
+                    @ApiResponse(responseCode = "502", description = "AI 서버 연동 실패")
+            })
     @GetMapping("/ping-ai")
     public ResponseEntity<String> pingAi() {
         try {
@@ -45,6 +53,7 @@ public class TestController {
     }
 
     // 토큰이 있어야 호출 가능한 테스트용
+    @Hidden
     @Operation(summary = "토큰 인증 테스트", description = "인증된 사용자만 호출 가능한 테스트용 API",
             security = @SecurityRequirement(name = "bearer-key")
     )

--- a/src/main/java/com/moa/moa_server/domain/global/controller/TestController.java
+++ b/src/main/java/com/moa/moa_server/domain/global/controller/TestController.java
@@ -3,6 +3,9 @@ package com.moa.moa_server.domain.global.controller;
 import com.moa.moa_server.domain.ai.client.AiModerationClient;
 import com.moa.moa_server.domain.ai.dto.ModerationRequest;
 import com.moa.moa_server.domain.ai.dto.ModerationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -11,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Test", description = "테스트용 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/test")
@@ -19,12 +23,14 @@ public class TestController {
     private final AiModerationClient aiModerationClient;
 
     // 누구나 호출 가능한 헬스체크용
+    @Operation(summary = " 서버 헬스 체크", description = "누구나 호출 가능한 ping API")
     @GetMapping("/ping")
     public ResponseEntity<String> ping() {
         return ResponseEntity.ok("pong");
     }
 
     // AI 서버 연동 테스트
+    @Operation(summary = "AI 서버 연동 테스트", description = "AI 서버에 문장을 보내 검열 결과를 받는 테스트용 API")
     @GetMapping("/ping-ai")
     public ResponseEntity<String> pingAi() {
         try {
@@ -39,7 +45,9 @@ public class TestController {
     }
 
     // 토큰이 있어야 호출 가능한 테스트용
-    // SecurityConfig에서 @AuthenticationPrincipal 처리되어 있어야 함
+    @Operation(summary = "토큰 인증 테스트", description = "인증된 사용자만 호출 가능한 테스트용 API",
+            security = @SecurityRequirement(name = "bearer-key")
+    )
     @PostMapping("/auth")
     public ResponseEntity<String> authTest(@AuthenticationPrincipal Long userId) {
         return ResponseEntity.ok("Authenticated user ID: " + userId);

--- a/src/main/java/com/moa/moa_server/domain/global/dto/ApiResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/global/dto/ApiResponse.java
@@ -1,3 +1,13 @@
 package com.moa.moa_server.domain.global.dto;
 
-public record ApiResponse(String message, Object data) {}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "공통 응답 객체")
+public record ApiResponse(
+
+        @Schema(description = "응답 메시지", example = "SUCCESS")
+        String message,
+
+        @Schema(description = "응답 데이터")
+        Object data
+) {}

--- a/src/main/java/com/moa/moa_server/domain/global/dto/ApiResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/global/dto/ApiResponse.java
@@ -3,11 +3,11 @@ package com.moa.moa_server.domain.global.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "공통 응답 객체")
-public record ApiResponse(
+public record ApiResponse<T>(
 
         @Schema(description = "응답 메시지", example = "SUCCESS")
         String message,
 
         @Schema(description = "응답 데이터")
-        Object data
+        T data
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/global/dto/ApiResponseVoid.java
+++ b/src/main/java/com/moa/moa_server/domain/global/dto/ApiResponseVoid.java
@@ -5,9 +5,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 // Swagger 전용 문서화용 빈 응답 DTO
 @Schema(description = "응답 데이터가 없는 공통 응답 객체")
 public record ApiResponseVoid(
-    @Schema(description = "응답 메시지", example = "SUCCESS")
-    String message,
 
-    @Schema(description = "응답 데이터", nullable = true, example = "null")
-    Object data
+        @Schema(description = "응답 메시지", example = "SUCCESS")
+        String message,
+
+        @Schema(description = "응답 데이터", nullable = true, example = "null")
+        Object data
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/global/dto/ApiResponseVoid.java
+++ b/src/main/java/com/moa/moa_server/domain/global/dto/ApiResponseVoid.java
@@ -1,0 +1,13 @@
+package com.moa.moa_server.domain.global.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// Swagger 전용 문서화용 빈 응답 DTO
+@Schema(description = "응답 데이터가 없는 공통 응답 객체")
+public record ApiResponseVoid(
+    @Schema(description = "응답 메시지", example = "SUCCESS")
+    String message,
+
+    @Schema(description = "응답 데이터", nullable = true, example = "null")
+    Object data
+) {}

--- a/src/main/java/com/moa/moa_server/domain/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/moa/moa_server/domain/global/handler/GlobalExceptionHandler.java
@@ -11,16 +11,16 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BaseException.class)
-    public ResponseEntity<ApiResponse> handleBaseException(BaseException ex) {
+    public ResponseEntity<ApiResponse<Void>> handleBaseException(BaseException ex) {
         return ResponseEntity
                 .status(ex.getStatus())
-                .body(new ApiResponse(ex.getCode(), null));
+                .body(new ApiResponse<>(ex.getCode(), null));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse> handleUnhandled(Exception ex) {
+    public ResponseEntity<ApiResponse<Void>> handleUnhandled(Exception ex) {
         return ResponseEntity
                 .status(500)
-                .body(new ApiResponse(GlobalErrorCode.UNEXPECTED_ERROR.name(), null));
+                .body(new ApiResponse<>(GlobalErrorCode.UNEXPECTED_ERROR.name(), null));
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/global/swagger/CommonErrorResponses.java
+++ b/src/main/java/com/moa/moa_server/domain/global/swagger/CommonErrorResponses.java
@@ -1,0 +1,50 @@
+package com.moa.moa_server.domain.global.swagger;
+
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponses({
+        @ApiResponse(responseCode = "401", description = "Unauthorized",
+                content = @io.swagger.v3.oas.annotations.media.Content(
+                        mediaType = "application/json",
+                        examples = {
+                                @ExampleObject(
+                                        name = "INVALID_TOKEN",
+                                        description = "토큰 없음 / 잘못된 토큰 / 토큰 만료",
+                                        value = "{\"message\": \"INVALID_TOKEN\", \"data\": null}"
+                                ),
+                                @ExampleObject(
+                                        name = "USER_NOT_FOUND",
+                                        description = "토큰 userId로 유저 찾을 수 없음",
+                                        value = "{\"message\": \"USER_NOT_FOUND\", \"data\": null}"
+                                ),
+                                @ExampleObject(
+                                        name = "USER_WITHDRAWN",
+                                        description = "탈퇴한 유저",
+                                        value = "{\"message\": \"USER_WITHDRAWN\", \"data\": null}"
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error",
+                content = @io.swagger.v3.oas.annotations.media.Content(
+                        mediaType = "application/json",
+                        examples =
+                                @ExampleObject(
+                                        name = "UNEXPECTED_ERROR",
+                                        description = "서버 내부 오류",
+                                        value = "{\"message\": \"UNEXPECTED_ERROR\", \"data\": null}"
+                                )
+                        )
+        )
+})
+public @interface CommonErrorResponses {
+}

--- a/src/main/java/com/moa/moa_server/domain/group/controller/GroupController.java
+++ b/src/main/java/com/moa/moa_server/domain/group/controller/GroupController.java
@@ -6,6 +6,8 @@ import com.moa.moa_server.domain.group.dto.request.GroupJoinRequest;
 import com.moa.moa_server.domain.group.dto.response.GroupCreateResponse;
 import com.moa.moa_server.domain.group.dto.response.GroupJoinResponse;
 import com.moa.moa_server.domain.group.service.GroupService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Group", description = "그룹 도메인 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/groups")
@@ -21,6 +24,7 @@ public class GroupController {
 
     private final GroupService groupService;
 
+    @Operation(summary = "그룹 가입", description = "초대 코드를 통해 사용자가 그룹에 참여합니다.")
     @PostMapping("/join")
     public ResponseEntity<ApiResponse> joinGroup(
             @AuthenticationPrincipal Long userId,
@@ -32,6 +36,7 @@ public class GroupController {
                 .body(new ApiResponse("SUCCESS", response));
     }
 
+    @Operation(summary = "그룹 생성")
     @PostMapping
     public ResponseEntity<ApiResponse> createGroup(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/moa/moa_server/domain/group/controller/GroupController.java
+++ b/src/main/java/com/moa/moa_server/domain/group/controller/GroupController.java
@@ -26,25 +26,25 @@ public class GroupController {
 
     @Operation(summary = "그룹 가입", description = "초대 코드를 통해 사용자가 그룹에 참여합니다.")
     @PostMapping("/join")
-    public ResponseEntity<ApiResponse> joinGroup(
+    public ResponseEntity<ApiResponse<GroupJoinResponse>> joinGroup(
             @AuthenticationPrincipal Long userId,
             @RequestBody GroupJoinRequest request
     ) {
         GroupJoinResponse response = groupService.joinGroup(userId, request);
         return ResponseEntity
                 .status(201)
-                .body(new ApiResponse("SUCCESS", response));
+                .body(new ApiResponse<>("SUCCESS", response));
     }
 
     @Operation(summary = "그룹 생성")
     @PostMapping
-    public ResponseEntity<ApiResponse> createGroup(
+    public ResponseEntity<ApiResponse<GroupCreateResponse>> createGroup(
             @AuthenticationPrincipal Long userId,
             @RequestBody GroupCreateRequest request
     ) {
         GroupCreateResponse response = groupService.createGroup(userId, request);
         return ResponseEntity
                 .status(201)
-                .body(new ApiResponse("SUCCESS", response));
+                .body(new ApiResponse<>("SUCCESS", response));
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/group/dto/request/GroupCreateRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/group/dto/request/GroupCreateRequest.java
@@ -1,7 +1,13 @@
 package com.moa.moa_server.domain.group.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "그룹 생성 요청 DTO")
 public record GroupCreateRequest(
+        @Schema(description = "그룹 이름", example = "춘식이 연구회")
         String name,
+        @Schema(description = "그룹 설명", example = "매일 춘식이 사진 공유")
         String description,
+        @Schema(description = "그룹 이미지 URL", example = "https://s3.amazonaws.com/....jpg")
         String imageUrl
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/group/dto/request/GroupJoinRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/group/dto/request/GroupJoinRequest.java
@@ -1,5 +1,9 @@
 package com.moa.moa_server.domain.group.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "그룹 가입 요청 DTO")
 public record GroupJoinRequest(
+        @Schema(description = "초대 코드", example = "EX39S1")
         String inviteCode
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/group/dto/response/GroupCreateResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/group/dto/response/GroupCreateResponse.java
@@ -1,12 +1,26 @@
 package com.moa.moa_server.domain.group.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
+@Schema(description = "그룹 생성 요청 응답 DTO")
 public record GroupCreateResponse(
+        @Schema(description = "생성된 그룹 ID", example = "17")
         Long groupId,
+
+        @Schema(description = "그룹 이름", example = "춘식이 연구회")
         String name,
+
+        @Schema(description = "그룹 설명", example = "매일 춘식이 사진 공유")
         String description,
+
+        @Schema(description = "그룹 이미지 URL", example = "https://s3.amazonaws.com/....jpg")
         String imageUrl,
+
+        @Schema(description = "초대 코드", example = "ABC123")
         String inviteCode,
+
+        @Schema(description = "생성 시각", example = "2025-04-25T14:00:00")
         LocalDateTime createdAt
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/group/dto/response/GroupJoinResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/group/dto/response/GroupJoinResponse.java
@@ -1,7 +1,15 @@
 package com.moa.moa_server.domain.group.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "그룹 가입 응답 DTO")
 public record GroupJoinResponse(
+        @Schema(description = "가입된 그룹 ID", example = "7")
         Long groupId,
+
+        @Schema(description = "그룹 이름", example = "카테부")
         String groupName,
+
+        @Schema(description = "가입된 역할", example = "MEMBER")
         String role
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
+++ b/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
@@ -7,11 +7,14 @@ import com.moa.moa_server.domain.user.dto.response.JoinedGroupResponse;
 import com.moa.moa_server.domain.user.dto.response.UserInfoResponse;
 import com.moa.moa_server.domain.user.dto.response.UserUpdateResponse;
 import com.moa.moa_server.domain.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "User", description = "유저 도메인 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/user")
@@ -19,6 +22,7 @@ public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "가입한 그룹 라벨 조회", description = "사용자가 가입한 그룹들의 Id와 이름을 조회합니다.")
     @GetMapping("/groups/labels")
     public ResponseEntity<ApiResponse> getJoinedGroupLabels(
             @AuthenticationPrincipal Long userId,
@@ -29,6 +33,7 @@ public class UserController {
         return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
     }
 
+    @Operation(summary = "가입한 그룹 목록 조회", description = "사용자가 가입한 그룹들의 상세 정보를 조회합니다.")
     @GetMapping("/groups")
     public ResponseEntity<ApiResponse> getJoinedGroups(
             @AuthenticationPrincipal Long userId,
@@ -39,6 +44,7 @@ public class UserController {
         return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
     }
 
+    @Operation(summary = "회원 정보 조회")
     @GetMapping
     public ResponseEntity<ApiResponse> getUserInfo(
             @AuthenticationPrincipal Long userId
@@ -47,6 +53,7 @@ public class UserController {
         return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
     }
 
+    @Operation(summary = "회원 정보 수정")
     @PatchMapping
     public ResponseEntity<ApiResponse> updateUserInfo(
             @AuthenticationPrincipal Long userId,
@@ -56,6 +63,7 @@ public class UserController {
         return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
     }
 
+    @Operation(summary = "회원 탈퇴")
     @DeleteMapping
     public ResponseEntity<ApiResponse> deleteUser(
             @AuthenticationPrincipal Long userId

--- a/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
+++ b/src/main/java/com/moa/moa_server/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.moa.moa_server.domain.user.controller;
 
 import com.moa.moa_server.domain.global.dto.ApiResponse;
+import com.moa.moa_server.domain.global.dto.ApiResponseVoid;
 import com.moa.moa_server.domain.user.dto.request.UserUpdateRequest;
 import com.moa.moa_server.domain.user.dto.response.GroupLabelResponse;
 import com.moa.moa_server.domain.user.dto.response.JoinedGroupResponse;
@@ -8,6 +9,8 @@ import com.moa.moa_server.domain.user.dto.response.UserInfoResponse;
 import com.moa.moa_server.domain.user.dto.response.UserUpdateResponse;
 import com.moa.moa_server.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,51 +27,58 @@ public class UserController {
 
     @Operation(summary = "가입한 그룹 라벨 조회", description = "사용자가 가입한 그룹들의 Id와 이름을 조회합니다.")
     @GetMapping("/groups/labels")
-    public ResponseEntity<ApiResponse> getJoinedGroupLabels(
+    public ResponseEntity<ApiResponse<GroupLabelResponse>> getJoinedGroupLabels(
             @AuthenticationPrincipal Long userId,
             @RequestParam(required = false) String cursor,
             @RequestParam(required = false) Integer size
     ) {
         GroupLabelResponse response = userService.getJoinedGroupLabels(userId, cursor, size);
-        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
+        return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
     }
 
     @Operation(summary = "가입한 그룹 목록 조회", description = "사용자가 가입한 그룹들의 상세 정보를 조회합니다.")
     @GetMapping("/groups")
-    public ResponseEntity<ApiResponse> getJoinedGroups(
+    public ResponseEntity<ApiResponse<JoinedGroupResponse>> getJoinedGroups(
             @AuthenticationPrincipal Long userId,
             @RequestParam(required = false) String cursor,
             @RequestParam(required = false) Integer size
     ) {
         JoinedGroupResponse response = userService.getJoinedGroups(userId, cursor, size);
-        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
+        return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
     }
 
     @Operation(summary = "회원 정보 조회")
     @GetMapping
-    public ResponseEntity<ApiResponse> getUserInfo(
+    public ResponseEntity<ApiResponse<UserInfoResponse>> getUserInfo(
             @AuthenticationPrincipal Long userId
     ) {
         UserInfoResponse response = userService.getUserInfo(userId);
-        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
+        return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
     }
 
     @Operation(summary = "회원 정보 수정")
     @PatchMapping
-    public ResponseEntity<ApiResponse> updateUserInfo(
+    public ResponseEntity<ApiResponse<UserUpdateResponse>> updateUserInfo(
             @AuthenticationPrincipal Long userId,
             @RequestBody UserUpdateRequest request
     ) {
         UserUpdateResponse response = userService.updateUserInfo(userId, request);
-        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
+        return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
     }
 
-    @Operation(summary = "회원 탈퇴")
+    @Operation(summary = "회원 탈퇴",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            content = @Content(schema = @Schema(implementation = ApiResponseVoid.class))
+                    )
+            }
+    )
     @DeleteMapping
-    public ResponseEntity<ApiResponse> deleteUser(
+    public ResponseEntity<ApiResponse<Void>> deleteUser(
             @AuthenticationPrincipal Long userId
     ) {
         userService.deleteUser(userId);
-        return ResponseEntity.ok(new ApiResponse("SUCCESS", null));
+        return ResponseEntity.ok(new ApiResponse<>("SUCCESS", null));
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/user/dto/request/UserUpdateRequest.java
@@ -1,5 +1,9 @@
 package com.moa.moa_server.domain.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원정보 수정 요청 DTO")
 public record UserUpdateRequest(
+        @Schema(description = "변경할 닉네임", example = "nickname")
         String nickname
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/user/dto/response/GroupDetail.java
+++ b/src/main/java/com/moa/moa_server/domain/user/dto/response/GroupDetail.java
@@ -2,13 +2,26 @@ package com.moa.moa_server.domain.user.dto.response;
 
 import com.moa.moa_server.domain.group.entity.Group;
 import com.moa.moa_server.domain.group.entity.GroupMember;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "그룹 정보")
 public record GroupDetail(
+        @Schema(description = "그룹 ID", example = "3")
         Long groupId,
+
+        @Schema(description = "그룹 이름", example = "카테부")
         String name,
+
+        @Schema(description = "그룹 소개", example = "카카오 부트캠프전용 야자타임 커뮤니티 입니다.")
         String description,
+
+        @Schema(description = "그룹 이미지 URL", example = "https://s3.amazonaws.com/....jpg")
         String imageUrl,
+
+        @Schema(description = "그룹 초대 코드", example = "E78XC1")
         String inviteCode,
+
+        @Schema(description = "그룹 내 사용자의 역할", example = "MEMBER")
         String role
 ) {
     public static GroupDetail from(Group group, GroupMember.Role role) {

--- a/src/main/java/com/moa/moa_server/domain/user/dto/response/GroupLabel.java
+++ b/src/main/java/com/moa/moa_server/domain/user/dto/response/GroupLabel.java
@@ -1,9 +1,14 @@
 package com.moa.moa_server.domain.user.dto.response;
 
 import com.moa.moa_server.domain.group.entity.Group;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "그룹 라벨")
 public record GroupLabel(
+        @Schema(description = "그룹 ID", example = "1")
         Long groupId,
+
+        @Schema(description = "그룹 이름", example = "공개")
         String name
 ) {
 

--- a/src/main/java/com/moa/moa_server/domain/user/dto/response/GroupLabelResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/user/dto/response/GroupLabelResponse.java
@@ -1,10 +1,20 @@
 package com.moa.moa_server.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "가입한 그룹 라벨 조회 응답 DTO")
 public record GroupLabelResponse(
+        @Schema(description = "그룹 목록")
         List<GroupLabel> groups,
+
+        @Schema(description = "현재 페이지의 마지막 항목 기준 커서", example = "공개_1")
         String nextCursor,
+
+        @Schema(description = "다음 페이지 여부", example = "false")
         boolean hasNext,
+
+        @Schema(description = "현재 받아온 리스트 길이", example = "1")
         int size
 ){}

--- a/src/main/java/com/moa/moa_server/domain/user/dto/response/JoinedGroupResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/user/dto/response/JoinedGroupResponse.java
@@ -1,10 +1,20 @@
 package com.moa.moa_server.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "가입한 그룹 목록 조회 응답 DTO")
 public record JoinedGroupResponse(
-    List<GroupDetail> groups,
-    String nextCursor,
-    boolean hasNext,
-    int size
+        @Schema(description = "그룹 목록")
+        List<GroupDetail> groups,
+
+        @Schema(description = "현재 페이지의 마지막 항목 기준 커서", example = "카테부_3")
+        String nextCursor,
+
+        @Schema(description = "다음 페이지 여부", example = "false")
+        boolean hasNext,
+
+        @Schema(description = "현재 받아온 리스트 길이", example = "1")
+        int size
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/user/dto/response/UserInfoResponse.java
@@ -1,6 +1,10 @@
 package com.moa.moa_server.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원정보 조회 응답 DTO")
 public record UserInfoResponse(
+        @Schema(description = "닉네임", example = "nickname")
         String nickname
 ) {
     public static UserInfoResponse from(String nickname) {

--- a/src/main/java/com/moa/moa_server/domain/user/dto/response/UserUpdateResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/user/dto/response/UserUpdateResponse.java
@@ -1,5 +1,9 @@
 package com.moa.moa_server.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원정보 수정 응답 DTO")
 public record UserUpdateResponse(
+        @Schema(description = "변경된 닉네임", example = "nickname")
         String nickname
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
@@ -10,11 +10,14 @@ import com.moa.moa_server.domain.vote.dto.response.mine.MyVoteResponse;
 import com.moa.moa_server.domain.vote.dto.response.result.VoteResultResponse;
 import com.moa.moa_server.domain.vote.dto.response.submitted.SubmittedVoteResponse;
 import com.moa.moa_server.domain.vote.service.VoteService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Vote", description = "투표 도메인 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/votes")
@@ -22,6 +25,7 @@ public class VoteController {
 
     private final VoteService voteService;
 
+    @Operation(summary = "투표 등록", description = "지정한 그룹 또는 전체 공개로 새 투표를 생성합니다.")
     @PostMapping
     public ResponseEntity<ApiResponse> createVote(
             @AuthenticationPrincipal Long userId,
@@ -35,6 +39,7 @@ public class VoteController {
                 .body(new ApiResponse("SUCCESS", new VoteCreateResponse(voteId)));
     }
 
+    @Operation(summary = "투표 참여", description = "투표 항목을 선택하여 진행 중인 투표에 참여합니다.")
     @PostMapping("/{voteId}/submit")
     public ResponseEntity<ApiResponse> submitVote(
             @AuthenticationPrincipal Long userId,
@@ -45,6 +50,7 @@ public class VoteController {
         return ResponseEntity.ok(new ApiResponse("SUCCESS", null));
     }
 
+    @Operation(summary = "투표 내용 조회", description = "투표 내용, 등록자, 종료 시각 등 투표 정보를 조회합니다.")
     @GetMapping("/{voteId}")
     public ResponseEntity<ApiResponse> getVoteDetail(
             @AuthenticationPrincipal Long userId,
@@ -54,6 +60,7 @@ public class VoteController {
         return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
     }
 
+    @Operation(summary = "투표 결과 조회", description = "투표의 전체 응답 수, 각 항목에 대한 응답 수와 비율 등 투표 결과를 조회합니다.")
     @GetMapping("/{voteId}/result")
     public ResponseEntity<ApiResponse> getVoteResult(
             @AuthenticationPrincipal Long userId,
@@ -63,6 +70,7 @@ public class VoteController {
         return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
     }
 
+    @Operation(summary = "진행 중인 투표 목록 조회", description = "사용자가 참여할 수 있는 진행 중인 투표 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse> getActiveVotes(
             @AuthenticationPrincipal Long userId,
@@ -74,6 +82,7 @@ public class VoteController {
         return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
     }
 
+    @Operation(summary = "내가 만든 투표 목록 조회", description = "사용자가 등록한 투표 목록을 조회합니다.")
     @GetMapping("/mine")
     public ResponseEntity<ApiResponse> getMyVotes(
             @AuthenticationPrincipal Long userId,
@@ -85,6 +94,7 @@ public class VoteController {
         return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
     }
 
+    @Operation(summary = "내가 참여한 투표 목록 조회", description = "사용자가 참여한 투표 목록을 조회합니다.")
     @GetMapping("/submit")
     public ResponseEntity<ApiResponse> getSubmittedVotes(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
@@ -1,6 +1,7 @@
 package com.moa.moa_server.domain.vote.controller;
 
 import com.moa.moa_server.domain.global.dto.ApiResponse;
+import com.moa.moa_server.domain.global.dto.ApiResponseVoid;
 import com.moa.moa_server.domain.vote.dto.request.VoteCreateRequest;
 import com.moa.moa_server.domain.vote.dto.request.VoteSubmitRequest;
 import com.moa.moa_server.domain.vote.dto.response.VoteCreateResponse;
@@ -11,6 +12,8 @@ import com.moa.moa_server.domain.vote.dto.response.result.VoteResultResponse;
 import com.moa.moa_server.domain.vote.dto.response.submitted.SubmittedVoteResponse;
 import com.moa.moa_server.domain.vote.service.VoteService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +30,7 @@ public class VoteController {
 
     @Operation(summary = "투표 등록", description = "지정한 그룹 또는 전체 공개로 새 투표를 생성합니다.")
     @PostMapping
-    public ResponseEntity<ApiResponse> createVote(
+    public ResponseEntity<ApiResponse<VoteCreateResponse>> createVote(
             @AuthenticationPrincipal Long userId,
             @RequestBody VoteCreateRequest request
     ) {
@@ -36,73 +39,80 @@ public class VoteController {
 
         return ResponseEntity
                 .status(201)
-                .body(new ApiResponse("SUCCESS", new VoteCreateResponse(voteId)));
+                .body(new ApiResponse<>("SUCCESS", new VoteCreateResponse(voteId)));
     }
 
-    @Operation(summary = "투표 참여", description = "투표 항목을 선택하여 진행 중인 투표에 참여합니다.")
+    @Operation(summary = "투표 참여", description = "투표 항목을 선택하여 진행 중인 투표에 참여합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            content = @Content(schema = @Schema(implementation = ApiResponseVoid.class))
+                    )
+            }
+    )
     @PostMapping("/{voteId}/submit")
-    public ResponseEntity<ApiResponse> submitVote(
+    public ResponseEntity<ApiResponse<Void>> submitVote(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long voteId,
             @RequestBody VoteSubmitRequest request
     ) {
         voteService.submitVote(userId, voteId, request);
-        return ResponseEntity.ok(new ApiResponse("SUCCESS", null));
+        return ResponseEntity.ok(new ApiResponse<>("SUCCESS", null));
     }
 
     @Operation(summary = "투표 내용 조회", description = "투표 내용, 등록자, 종료 시각 등 투표 정보를 조회합니다.")
     @GetMapping("/{voteId}")
-    public ResponseEntity<ApiResponse> getVoteDetail(
+    public ResponseEntity<ApiResponse<VoteDetailResponse>> getVoteDetail(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long voteId
     ) {
         VoteDetailResponse response = voteService.getVoteDetail(userId, voteId);
-        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
+        return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
     }
 
     @Operation(summary = "투표 결과 조회", description = "투표의 전체 응답 수, 각 항목에 대한 응답 수와 비율 등 투표 결과를 조회합니다.")
     @GetMapping("/{voteId}/result")
-    public ResponseEntity<ApiResponse> getVoteResult(
+    public ResponseEntity<ApiResponse<VoteResultResponse>> getVoteResult(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long voteId
     ) {
         VoteResultResponse response = voteService.getVoteResult(userId, voteId);
-        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
+        return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
     }
 
     @Operation(summary = "진행 중인 투표 목록 조회", description = "사용자가 참여할 수 있는 진행 중인 투표 목록을 조회합니다.")
     @GetMapping
-    public ResponseEntity<ApiResponse> getActiveVotes(
+    public ResponseEntity<ApiResponse<ActiveVoteResponse>> getActiveVotes(
             @AuthenticationPrincipal Long userId,
             @RequestParam(required = false) Long groupId,
             @RequestParam(required = false) String cursor,
             @RequestParam(required = false) Integer size
     ) {
         ActiveVoteResponse response = voteService.getActiveVotes(userId, groupId, cursor, size);
-        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
+        return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
     }
 
     @Operation(summary = "내가 만든 투표 목록 조회", description = "사용자가 등록한 투표 목록을 조회합니다.")
     @GetMapping("/mine")
-    public ResponseEntity<ApiResponse> getMyVotes(
+    public ResponseEntity<ApiResponse<MyVoteResponse>> getMyVotes(
             @AuthenticationPrincipal Long userId,
             @RequestParam(required = false) Long groupId,
             @RequestParam(required = false) String cursor,
             @RequestParam(required = false) Integer size
     ) {
         MyVoteResponse response = voteService.getMyVotes(userId, groupId, cursor, size);
-        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
+        return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
     }
 
     @Operation(summary = "내가 참여한 투표 목록 조회", description = "사용자가 참여한 투표 목록을 조회합니다.")
     @GetMapping("/submit")
-    public ResponseEntity<ApiResponse> getSubmittedVotes(
+    public ResponseEntity<ApiResponse<SubmittedVoteResponse>> getSubmittedVotes(
             @AuthenticationPrincipal Long userId,
             @RequestParam(required = false) Long groupId,
             @RequestParam(required = false) String cursor,
             @RequestParam(required = false) Integer size
     ) {
         SubmittedVoteResponse response = voteService.getSubmittedVotes(userId, groupId, cursor, size);
-        return ResponseEntity.ok(new ApiResponse("SUCCESS", response));
+        return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteModerationController.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteModerationController.java
@@ -4,6 +4,8 @@ import com.moa.moa_server.domain.global.dto.ApiResponse;
 import com.moa.moa_server.domain.vote.dto.moderation.VoteModerationCallbackRequest;
 import com.moa.moa_server.domain.vote.dto.moderation.VoteModerationCallbackResponse;
 import com.moa.moa_server.domain.vote.service.VoteModerationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Vote Moderation", description = "AI 서버가 호출하는 투표 검열 도메인 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/ai")
@@ -18,6 +21,7 @@ public class VoteModerationController {
 
     private final VoteModerationService voteModerationService;
 
+    @Operation(summary = "AI 검열 결과 콜백 처리", description = "\"AI 서버가 투표 내용을 검열한 결과를 백엔드 서버에 전달합니다. 해당 API는 AI 서버에서 직접 호출합니다.")
     @PostMapping("/votes/moderation/callback")
     public ResponseEntity<ApiResponse> callback(
             @RequestBody VoteModerationCallbackRequest request

--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteModerationController.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteModerationController.java
@@ -23,12 +23,12 @@ public class VoteModerationController {
 
     @Operation(summary = "AI 검열 결과 콜백 처리", description = "\"AI 서버가 투표 내용을 검열한 결과를 백엔드 서버에 전달합니다. 해당 API는 AI 서버에서 직접 호출합니다.")
     @PostMapping("/votes/moderation/callback")
-    public ResponseEntity<ApiResponse> callback(
+    public ResponseEntity<ApiResponse<VoteModerationCallbackResponse>> callback(
             @RequestBody VoteModerationCallbackRequest request
     ) {
         VoteModerationCallbackResponse result = voteModerationService.handleCallback(request);
         return ResponseEntity
                 .status(201)
-                .body(new ApiResponse("SUCCESS", result));
+                .body(new ApiResponse<>("SUCCESS", result));
     }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/moderation/VoteModerationCallbackRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/moderation/VoteModerationCallbackRequest.java
@@ -1,9 +1,22 @@
 package com.moa.moa_server.domain.vote.dto.moderation;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "검열 결과 콜백 요청 DTO")
 public record VoteModerationCallbackRequest(
+
+        @Schema(description = "투표 ID", example = "123")
         Long voteId,
+
+        @Schema(description = "검열 결과", example = "APPROVED")
         String result,
+
+        @Schema(description = "검열 사유", example = "NONE")
         String reason,
+
+        @Schema(description = "상세 사유", example = "적절한 표현입니다.")
         String reasonDetail,
+
+        @Schema(description = "AI 모델 버전 정보", example = "1.0.0")
         String version
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/moderation/VoteModerationCallbackResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/moderation/VoteModerationCallbackResponse.java
@@ -1,6 +1,12 @@
 package com.moa.moa_server.domain.vote.dto.moderation;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "투표 내용 검열 요청 DTO")
 public record VoteModerationCallbackResponse(
+        @Schema(description = "투표 ID", example = "123")
         Long voteId,
+
+        @Schema(description = "결과가 정상 저장되었는지 여부", example = "true")
         boolean stored
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/moderation/VoteModerationRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/moderation/VoteModerationRequest.java
@@ -1,6 +1,12 @@
 package com.moa.moa_server.domain.vote.dto.moderation;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "투표 내용 검열 요청 DTO")
 public record VoteModerationRequest(
+        @Schema(description = "투표 ID", example = "123")
         Long voteId,
+
+        @Schema(description = "투표 내용", example = "에어컨 추우신 분?")
         String content
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/request/VoteCreateRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/request/VoteCreateRequest.java
@@ -1,11 +1,23 @@
 package com.moa.moa_server.domain.vote.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
+@Schema(description = "투표 등록 요청 DTO")
 public record VoteCreateRequest(
+        @Schema(description = "투표가 속할 그룹 ID", example = "1")
         Long groupId,
+
+        @Schema(description = "투표 본문 내용", example = "에어컨 추우신 분?")
         String content,
+
+        @Schema(description = "첨부 이미지 URL", example = "https://s3.amazonaws.com/....jpg")
         String imageUrl,
+
+        @Schema(description = "투표 종료 일시", example = "2025-04-21T12:00:00")
         LocalDateTime closedAt,
+
+        @Schema(description = "투표 등록 익명 여부", example = "false")
         Boolean anonymous
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/request/VoteSubmitRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/request/VoteSubmitRequest.java
@@ -1,5 +1,9 @@
 package com.moa.moa_server.domain.vote.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "투표 참여 요청 DTO")
 public record VoteSubmitRequest(
+        @Schema(description = "사용자가 선택한 항목 번호 (0: 기권, 1: Yes, 2: No)", example = "2")
         int userResponse
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteCreateResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteCreateResponse.java
@@ -1,5 +1,10 @@
 package com.moa.moa_server.domain.vote.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "투표 등록 응답 DTO")
 public record VoteCreateResponse(
-    Long voteId
+
+        @Schema(description = "등록된 투표 ID", example = "123")
+        Long voteId
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteDetailResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteDetailResponse.java
@@ -1,14 +1,33 @@
 package com.moa.moa_server.domain.vote.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
+@Schema(description = "투표 내용 조회 응답 DTO")
 public record VoteDetailResponse(
+
+        @Schema(description = "투표 ID", example = "123")
         Long voteId,
+
+        @Schema(description = "투표가 속한 그룹 ID", example = "1")
         Long groupId,
+
+        @Schema(description = "투표 등록자 닉네임 (익명 투표인 경우, '익명'으로 전달)", example = "nickname")
         String authorNickname,
+
+        @Schema(description = "투표 본문 내용", example = "에어컨 추우신 분?")
         String content,
+
+        @Schema(description = "투표 이미지 URL (없으면 null)", example = "https://s3.amazonaws.com/....jpg")
         String imageUrl,
+
+        @Schema(description = "투표 시작 시각", example = "2025-04-20T12:00:00")
         LocalDateTime createdAt,
+
+        @Schema(description = "투표 종료 시각", example = "2025-04-21T12:00:00")
         LocalDateTime closedAt,
+
+        @Schema(description = "관리자 투표 여부 (0: 일반 투표, 1: 그룹 관리자 생성 투표)", example = "0")
         int adminVote
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteOptionResultWithId.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteOptionResultWithId.java
@@ -1,8 +1,19 @@
 package com.moa.moa_server.domain.vote.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "항목별 결과 with 투표 ID")
 public record VoteOptionResultWithId(
+
+        @Schema(description = "투표 ID", example = "123")
         Long voteId,
+
+        @Schema(description = "항목 번호 (1: Yes, 2: No)", example = "1")
         int optionNumber,
+
+        @Schema(description = "해당 항목에 투표한 수", example = "3")
         int count,
+
+        @Schema(description = "해당 항목 비율 (소수점 포함)", example = "30")
         double ratio
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/active/ActiveVoteItem.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/active/ActiveVoteItem.java
@@ -1,18 +1,38 @@
 package com.moa.moa_server.domain.vote.dto.response.active;
 
 import com.moa.moa_server.domain.vote.entity.Vote;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "진행 중인 투표 정보")
 public record ActiveVoteItem(
+
+        @Schema(description = "투표 ID", example = "123")
         Long voteId,
+
+        @Schema(description = "투표가 속한 그룹 ID", example = "1")
         Long groupId,
+
+        @Schema(description = "투표 등록자 닉네임 (익명 투표인 경우, '익명'으로 전달)", example = "nickname")
         String authorNickname,
+
+        @Schema(description = "투표 본문 내용", example = "에어컨 추우신 분?")
         String content,
+
+        @Schema(description = "투표 이미지 URL (없으면 null)", example = "https://s3.amazonaws.com/....jpg")
         String imageUrl,
+
+        @Schema(description = "투표 시작 시각", example = "2025-04-20T12:00:00")
         LocalDateTime createdAt,
+
+        @Schema(description = "투표 종료 시각", example = "2025-04-21T12:00:00")
         LocalDateTime closedAt,
+
+        @Schema(description = "관리자 투표 여부 (0: 일반 투표, 1: 그룹 관리자 생성 투표)", example = "0")
         int adminVote,
+
+        @Schema(description = "투표 성격 (USER, AI, EVENT 중 하나)", example = "USER")
         String voteType
 ) {
 

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/active/ActiveVoteResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/active/ActiveVoteResponse.java
@@ -1,10 +1,21 @@
 package com.moa.moa_server.domain.vote.dto.response.active;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "진행 중인 투표 목록 조회 응답 DTO")
 public record ActiveVoteResponse(
+
+        @Schema(description = "투표 목록")
         List<ActiveVoteItem> votes,
+
+        @Schema(description = "현재 페이지의 마지막 항목 기준 커서", example = "2025-04-21T12:00:00_2025-04-20T12:00:00")
         String nextCursor,
+
+        @Schema(description = "다음 페이지 여부", example = "false")
         boolean hasNext,
+
+        @Schema(description = "현재 받아온 리스트 길이", example = "1")
         int size
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/mine/MyVoteItem.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/mine/MyVoteItem.java
@@ -2,17 +2,33 @@ package com.moa.moa_server.domain.vote.dto.response.mine;
 
 import com.moa.moa_server.domain.vote.dto.response.VoteOptionResultWithId;
 import com.moa.moa_server.domain.vote.entity.Vote;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "내가 만든 투표 정보")
 public record MyVoteItem(
+
+        @Schema(description = "투표 ID", example = "123")
         Long voteId,
+
+        @Schema(description = "투표가 속한 그룹 ID", example = "1")
         Long groupId,
+
+        @Schema(description = "투표 본문 내용", example = "에어컨 추우신 분?")
         String content,
+
+        @Schema(description = "투표 진행 상태 ('PENDING': 검토중, 'REJECTED': 등록실패, 'OPEN': 진행중, 'CLOSED': 종료됨)", example = "OPEN")
         String voteStatus,
+
+        @Schema(description = "투표 시작 시각", example = "2025-04-20T12:00:00")
         LocalDateTime createdAt,
+
+        @Schema(description = "투표 종료 시각", example = "2025-04-21T12:00:00")
         LocalDateTime closedAt,
+
+        @Schema(description = "항목별 결과 리스트 (voteStatus가 'PENDING', 'REJECTED'인 경우 null)")
         List<VoteOptionResultWithId> results
 ) {
 

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/mine/MyVoteResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/mine/MyVoteResponse.java
@@ -1,12 +1,23 @@
 package com.moa.moa_server.domain.vote.dto.response.mine;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "내가 만든 투표 목록 조회 응답 DTO")
 public record MyVoteResponse(
-    List<MyVoteItem> votes,
-    String nextCursor,
-    boolean hasNext,
-    int size
+
+        @Schema(description = "투표 목록")
+        List<MyVoteItem> votes,
+
+        @Schema(description = "현재 페이지의 마지막 항목 기준 커서", example = "2025-04-21T12:00:00_2025-04-20T12:00:00")
+        String nextCursor,
+
+        @Schema(description = "다음 페이지 여부", example = "false")
+        boolean hasNext,
+
+        @Schema(description = "현재 받아온 리스트 길이", example = "1")
+        int size
 ) {
     public static MyVoteResponse of(List<MyVoteItem> votes, String nextCursor, boolean hasNext) {
         return new MyVoteResponse(votes, nextCursor, hasNext, votes.size());

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/result/VoteOptionResult.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/result/VoteOptionResult.java
@@ -1,7 +1,16 @@
 package com.moa.moa_server.domain.vote.dto.response.result;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "항목별 결과")
 public record VoteOptionResult(
+
+        @Schema(description = "항목 번호 (1: Yes, 2: No)", example = "1")
         int optionNumber,
+
+        @Schema(description = "해당 항목에 투표한 수", example = "3")
         int count,
+
+        @Schema(description = "해당 항목 비율 (소수점 포함)", example = "30")
         double ratio
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/result/VoteResultResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/result/VoteResultResponse.java
@@ -1,10 +1,21 @@
 package com.moa.moa_server.domain.vote.dto.response.result;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "투표 결과 조회 응답 DTO")
 public record VoteResultResponse (
+
+        @Schema(description = "조회한 투표 ID", example = "123")
         Long voteId,
+
+        @Schema(description = "사용자가 선택한 항목 번호 (0: 기권, 1: Yes, 2: No, null: 미참여)", example = "2")
         Integer userResponse,
+
+        @Schema(description = "전체 투표 수", example = "10")
         int totalCount,
+
+        @Schema(description = "항목별 결과 리스트")
         List<VoteOptionResult> results
 ) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/submitted/SubmittedVoteItem.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/submitted/SubmittedVoteItem.java
@@ -2,16 +2,30 @@ package com.moa.moa_server.domain.vote.dto.response.submitted;
 
 import com.moa.moa_server.domain.vote.dto.response.VoteOptionResultWithId;
 import com.moa.moa_server.domain.vote.entity.Vote;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "내가 참여한 투표 정보")
 public record SubmittedVoteItem(
+
+        @Schema(description = "투표 ID", example = "123")
         Long voteId,
+
+        @Schema(description = "투표가 속한 그룹 ID", example = "1")
         Long groupId,
+
+        @Schema(description = "투표 본문 내용", example = "에어컨 추우신 분?")
         String content,
+
+        @Schema(description = "투표 시작 시각", example = "2025-04-20T12:00:00")
         LocalDateTime createdAt,
+
+        @Schema(description = "투표 종료 시각", example = "2025-04-21T12:00:00")
         LocalDateTime closedAt,
+
+        @Schema(description = "항목별 결과 리스트 (voteStatus가 'PENDING', 'REJECTED'인 경우 null)")
         List<VoteOptionResultWithId> results
 ) {
     public static SubmittedVoteItem from(Vote vote, List<VoteOptionResultWithId> results) {

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/submitted/SubmittedVoteResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/submitted/SubmittedVoteResponse.java
@@ -1,11 +1,22 @@
 package com.moa.moa_server.domain.vote.dto.response.submitted;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "내가 참여한 투표 목록 조회 응답 DTO")
 public record SubmittedVoteResponse(
+
+        @Schema(description = "투표 목록")
         List<SubmittedVoteItem> votes,
+
+        @Schema(description = "현재 페이지의 마지막 항목 기준 커서", example = "2025-04-21T12:00:00_2025-04-20T12:00:00")
         String nextCursor,
+
+        @Schema(description = "다음 페이지 여부", example = "false")
         boolean hasNext,
+
+        @Schema(description = "현재 받아온 리스트 길이", example = "1")
         int size
 ) {
     public static SubmittedVoteResponse of(List<SubmittedVoteItem> votes, String nextCursor, boolean hasNext) {

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -25,10 +25,6 @@ mock:
   ai:
     enabled: false
 
-springdoc:
-  swagger-ui:
-    path: /_docs-d3v-p0rt4l
-
 logging:
   level:
     root: INFO

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -25,6 +25,10 @@ mock:
   ai:
     enabled: false
 
+springdoc:
+  swagger-ui:
+    path: /_docs-d3v-p0rt4l
+
 logging:
   level:
     root: INFO

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -30,4 +30,3 @@ logging:
   level:
     org.springframework.security: DEBUG
     org.hibernate.type.descriptor.sql: trace
-    org.springframework.security.web.FilterChainProxy: INFO

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -26,6 +26,10 @@ mock:
   ai:
     enabled: true
 
+springdoc:
+  swagger-ui:
+    path: /_docs-l0c4l-d3v-ui
+
 logging:
   level:
     org.springframework.security: DEBUG

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -26,10 +26,6 @@ mock:
   ai:
     enabled: true
 
-springdoc:
-  swagger-ui:
-    path: /_docs-l0c4l-d3v-ui
-
 logging:
   level:
     org.springframework.security: DEBUG

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -30,3 +30,4 @@ logging:
   level:
     org.springframework.security: DEBUG
     org.hibernate.type.descriptor.sql: trace
+    org.springframework.security.web.FilterChainProxy: INFO

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -25,6 +25,12 @@ frontend:
 ai:
   server-url: ${AI_SERVER_URL}
 
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false
+
 logging:
   level:
     root: INFO


### PR DESCRIPTION
## 관련 이슈
- Closes #91 

## 작업 개요
- springdoc-openapi를 활용한 Swagger 문서화 자동화

## 작업 상세

### ▪️ 기본 도입
- `springdoc-openapi` 의존성 추가
- SwaggerConfig 작성 (API 제목, 설명, 버전 명시)
- Swagger UI 기본 경로 테스트: `/swagger-ui/index.html`

### ▪️ 보안 및 환경 설정
- `local`, `dev` 환경에서만 Swagger 활성화
- `prod` 환경에서는 Swagger 비활성화 처리
- Swagger 문서 경로 커스터마이징 시도 (`/_docs-l0c4l-d3v-ui`) → 실패
  - 이유: springdoc가 `/swagger-ui`로 리다이렉트하여 보안 효과 없음
- 최종적으로 dev 환경에서는 "인증된 사용자만 Swagger 접근 허용"하는 방향이 필요함 (현재는 보류)

### ▪️ 문서화
- 모든 컨트롤러에 `@Tag`, 각 API에 `@Operation` 추가
- 요청/응답 DTO에 `@Schema(description, example)` 작성
- **공통 응답 객체 `ApiResponse<T>` 제네릭화** 및 문서화
- `ApiResponseVoid`, `CommonErrorResponses`, `LoginResponses` 등 커스텀 어노테이션을 통한 에러 응답 명세화 (AuthController에만 적용)

## 테스트
- [x] Swagger UI에서 모든 API 노출 확인
- [x] 인증 API 테스트용 토큰 전달 기능 정상 작동 확인
- [x] Swagger를 통해 예시, 설명, 필드 누락 등 시각적 검토 완료
- [x] FE 팀원 확인 완료 (`@gunhee0421`, 5/19)

## 기타 논의 사항
- 현재 Swagger 인증 제한은 도입하지 않음. 개발 편의성을 위해 admin 계정 로그인 과정 생략
- Swagger 문서는 프론트엔드와의 협업 기준으로 사용될 예정
- Swagger 접속 주소는 기존 Notion API 문서에 별도 기록하였음