### PR TITLE
feat: lucy-xss-filter 기반 XSS 필터링 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,10 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
+
+	configureEach {
+		exclude group: 'commons-logging', module: 'commons-logging'
+	}
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ dependencies {
 
 	implementation "org.apache.httpcomponents.client5:httpclient5:5.4.4"
 
+	implementation 'com.navercorp.lucy:lucy-xss:1.6.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/moa/moa_server/domain/global/util/XssUtil.java
+++ b/src/main/java/com/moa/moa_server/domain/global/util/XssUtil.java
@@ -1,0 +1,14 @@
+package com.moa.moa_server.domain.global.util;
+
+import com.nhncorp.lucy.security.xss.XssFilter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class XssUtil {
+    private static final XssFilter xssFilter = XssFilter.getInstance("lucy-xss-superset.xml");
+
+    public static String sanitize(String input) {
+        if (input == null) return null;
+        return xssFilter.doFilter(input);
+    }
+}

--- a/src/main/java/com/moa/moa_server/domain/group/service/GroupService.java
+++ b/src/main/java/com/moa/moa_server/domain/group/service/GroupService.java
@@ -1,5 +1,6 @@
 package com.moa.moa_server.domain.group.service;
 
+import com.moa.moa_server.domain.global.util.XssUtil;
 import com.moa.moa_server.domain.group.dto.request.GroupCreateRequest;
 import com.moa.moa_server.domain.group.dto.request.GroupJoinRequest;
 import com.moa.moa_server.domain.group.dto.response.GroupCreateResponse;
@@ -111,7 +112,8 @@ public class GroupService {
         String inviteCode = generateUniqueInviteCode();
 
         // 그룹 생성
-        Group group = Group.create(user, request.name(), request.description(), imageUrl, inviteCode);
+        String sanitizedDescription = XssUtil.sanitize(request.description());
+        Group group = Group.create(user, request.name(), sanitizedDescription, imageUrl, inviteCode);
         groupRepository.save(group);
 
         // 그룹 멤버 등록

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -3,6 +3,7 @@ package com.moa.moa_server.domain.vote.service;
 import com.moa.moa_server.domain.global.cursor.ClosedAtVoteIdCursor;
 import com.moa.moa_server.domain.global.cursor.CreatedAtVoteIdCursor;
 import com.moa.moa_server.domain.global.cursor.VoteClosedCursor;
+import com.moa.moa_server.domain.global.util.XssUtil;
 import com.moa.moa_server.domain.group.entity.Group;
 import com.moa.moa_server.domain.group.entity.GroupMember;
 import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
@@ -100,10 +101,12 @@ public class VoteService {
         Vote.VoteStatus status = "prod".equals(activeProfile) ? Vote.VoteStatus.PENDING : Vote.VoteStatus.OPEN;
 
         // Vote 생성 및 저장
+        String sanitizedContent = XssUtil.sanitize(request.content());
+
         Vote vote = Vote.createUserVote(
                 user,
                 group,
-                request.content(),
+                sanitizedContent,
                 imageUrl,
                 utcTime,
                 request.anonymous(),

--- a/src/main/resources/lucy-xss-superset.xml
+++ b/src/main/resources/lucy-xss-superset.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- version 20180725-1 -->
+<config xmlns="http://www.nhncorp.com/lucy-xss">
+	<denyTagComment>false</denyTagComment>
+	<elementRule>
+		<element name="body" disable="true" /> <!-- <BODY ONLOAD=alert("XSS")>, <BODY BACKGROUND="javascript:alert('XSS')"> -->
+		<element name="embed" disable="true" />
+		<element name="iframe" disable="true" /> <!-- <IFRAME SRC=”http://hacker-site.com/xss.html”> -->
+		<element name="meta" disable="true" />
+		<element name="object" disable="true" />
+		<element name="script" disable="true" /> <!-- <SCRIPT> alert(“XSS”); </SCRIPT> -->
+		<element name="style" disable="true" />
+		<element name="link" disable="true" />
+		<element name="base" disable="true" />
+		<element name="button" endTag="true">
+			<attributes>
+				<ref name="Attrs"/>
+				<ref name="name"/>
+				<ref name="value"/>
+				<ref name="type"/>
+				<ref name="disabled"/>
+				<ref name="tabindex"/>
+				<ref name="accesskey"/>
+				<ref name="Html5GlobalAttr"/>
+				<ref name="autofocus"/>
+				<ref name="form"/>
+				<ref name="formenctype"/>
+				<ref name="formmethod"/>
+				<ref name="formnovalidate"/>
+				<ref name="formtarget"/>
+			</attributes>
+		</element>
+	</elementRule>
+	<attributeRule>
+		<attribute name="data" base64Decoding="true">
+			<notAllowedPattern><![CDATA[(?i:s\\*c\\*r\\*i\\*p\\*t\\*:)]]></notAllowedPattern>
+			<notAllowedPattern><![CDATA[(?i:d\\*a\\*t\\*a\\*:)]]></notAllowedPattern>
+			<notAllowedPattern><![CDATA[&[#\\%x]+[\da-fA-F][\da-fA-F]+]]></notAllowedPattern>
+		</attribute>
+		<attribute name="src" base64Decoding="true">
+			<notAllowedPattern><![CDATA[(?i:s\\*c\\*r\\*i\\*p\\*t\\*:)]]></notAllowedPattern>
+			<notAllowedPattern><![CDATA[(?i:d\\*a\\*t\\*a\\*:)]]></notAllowedPattern>
+			<notAllowedPattern><![CDATA[&[#\\%x]+[\da-fA-F][\da-fA-F]+]]></notAllowedPattern>
+		</attribute>
+		<attribute name="style">
+			<notAllowedPattern><![CDATA[(?i:j\\*a\\*v\\*a\\*s\\*c\\*r\\*i\\*p\\*t\\*:)]]></notAllowedPattern>
+			<notAllowedPattern><![CDATA[(?i:e\\*x\\*p\\*r\\*e\\*s\\*s\\*i\\*o\\*n)]]></notAllowedPattern>
+			<notAllowedPattern><![CDATA[&[#\\%x]+[\da-fA-F][\da-fA-F]+]]></notAllowedPattern>
+		</attribute>
+		<attribute name="href">
+  			<notAllowedPattern><![CDATA[(?i:j\\*a\\*v\\*a\\*s\\*c\\*r\\*i\\*p\\*t\\*:)]]></notAllowedPattern>
+			<notAllowedPattern><![CDATA[&[#\\%x]+[\da-fA-F][\da-fA-F]+]]></notAllowedPattern>
+ 		</attribute>
+	</attributeRule>
+</config>


### PR DESCRIPTION
## 관련 이슈
- Closes #95

## 작업 개요
- lucy-xss-filter 기반 XSS 필터링 적용

## 작업 상세
- 사용자 입력이 저장되는 주요 필드에 XSS 필터 적용
    - 적용 대상: 투표 본문(Vote.content), 그룹 소개(Group.description)
    - 비적용 대상: 닉네임, 그룹 이름 등 글자 수 제한(12자)으로 인해 XSS 위험이 낮은 필드
- XssUtil 유틸리티 클래스 구현
    - lucy-xss.xml 설정 기반으로 필터 초기화
    - 요청 시점에서 수동 필터링 수행

## 테스트
- [x] 실제 악성 스크립트 입력 시 `<script>` → `&lt;script&gt;` 으로 정상 치환되는지 확인

## 기타 논의 사항
- 없음