### PR TITLE
chore: checkstyle 검사에서 QueryDSL Q클래스 제외

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,10 @@ tasks.named('test') {
 	useJUnitPlatform()
 }
 
+tasks.named("checkstyleMain") {
+  dependsOn tasks.named("compileJava")
+}
+
 // QueryDSL Q파일 생성용
 def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -33,8 +33,7 @@
 
   <!-- https://checkstyle.org/filters/suppressionfilter.html -->
   <module name="SuppressionFilter">
-    <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
-           default="checkstyle-suppressions.xml" />
+    <property name="file" value="${checkstyle.suppressions.file}" />
     <property name="optional" value="true"/>
   </module>
 

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -3,4 +3,5 @@
   "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
   "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 <suppressions>
+  <suppress files=".*[\\/]build[\\/]generated[\\/]querydsl[\\/].*" checks=".*"/>
 </suppressions>


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #118

## 🔗 작업 배경

- QueryDSL Q클래스는 컴파일 시 자동 생성되는 코드로, 스타일 규칙 위반이 잦고 수동 수정이 불가능합니다.
- CI 단계에서는 해당 클래스가 생성되지 않아 문제가 없지만,
   CD 파이프라인에서는 ./gradlew build 과정에서 Q클래스가 생성되고, 이후 checkstyleMain이 실행되면서 스타일 위반이 발생해 배포가 중단되는 문제가 있었습니다.

## 🔥 작업 개요
- QueryDSL Q클래스가 checkstyle 검사에 포함되지 않도록 예외 처리

## 🛠️ 작업 상세
- `build/generated/querydsl` 디렉토리 내 파일을 checkstyle 검사에서 제외
    - `suppressions.xml`에 해당 경로 추가 (`files=".*[\\/]build[\\/]generated[\\/]querydsl[\\/].*"`)

## 🧪 테스트
- [x] 로컬 `./gradlew checkstyleMain` 실행 시 Q클래스 관련 오류 발생하지 않음
- [ ] GitHub Actions에서 스타일 검사 통과 확인

## 💬 기타 논의 사항
- 자동 생성된 소스는 checkstyle 대상에서 제외하는 것이 일반적
