### PR TITLE
fix: checkstyleMain 의존성 명시로 CD 빌드 오류 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ tasks.named('test') {
 }
 
 tasks.named("checkstyleMain") {
-  dependsOn tasks.named("compileJava")
+  dependsOn "compileJava", "compileTestJava"
 }
 
 // QueryDSL Q파일 생성용


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #120 


## 🔧 작업 배경
- QueryDSL Q클래스는 APT(annotation processor)에 의해 build/generated/querydsl 하위에 자동 생성됩니다.

- 앞서 #119 에서 Q클래스를 checkstyle 검사 대상에서 제외했지만, 
   Gradle 8+부터는 그 디렉토리를 참조만 해도 해당 디렉토리를 만드는 태스크와의 명시적 의존성이 요구됩니다.

- 기존에는 compileJava만 의존하도록 설정했지만, CD 환경에서는 Q클래스가 compileTestJava 경로로도 생성되어서, Gradle이 의존성 선언을 하지 않았다는 오류를 냈습니다.
- 이로 인해 CD 파이프라인에서 checkstyleMain 실행 시 빌드가 실패했습니다.


## 🛠️ 작업 상세
- checkstyleMain 태스크에 Q클래스를 생성하는 태스크를 명시적으로 의존하도록 설정하여 빌드 타이밍 문제 해결

```groovy
tasks.named("checkstyleMain") {
  dependsOn "compileJava", "compileTestJava"
}
```


## ✅ 테스트

- [x] CD 파이프라인에서 빌드 실패하였던 `./gradlew clean build -x test`를 로컬에서 실행하여 해결된 것 확인


## 💬 기타 논의 사항
- 없음

