### PR TITLE
feat: 테스트용 로그인 API 및 더미 데이터 삽입 SQL 스크립트 추가

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,19 @@
+# Test Data SQL Scripts
+
+이 디렉토리는 **성능 테스트** 및 **기능 검증**을 위한 더미 데이터를 삽입하는 SQL 스크립트를 포함하고 있습니다.
+
+## 사용 방법
+
+1. 사전 조건
+   1. `user`, `vote`, `vote_response` 테이블이 생성되어 있어야 한다.
+   2. `init-data.sql`을 먼저 실행해, 기본 시스템 데이터가 생성되어 있어야 한다.
+2. MySQL 접속 후 `moa` 데이터베이스 선택
+3. 아래 순서로 실행
+   ```bash
+    source scripts/db/testdata/truncate_all.sql;
+    source scripts/db/testdata/init_users.sql;
+    source scripts/db/testdata/init_votes.sql;
+    source scripts/db/testdata/init_vote_responses.sql;
+
+## 주의 사항
+> 이 스크립트는 테스트 용도입니다. 프로덕션 환경에서는 절대 실행하지 마세요.

--- a/db/testdata/init_users.sql
+++ b/db/testdata/init_users.sql
@@ -1,0 +1,44 @@
+USE moa;
+
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS insert_users$$
+
+CREATE PROCEDURE insert_users()
+BEGIN
+  DECLARE i INT DEFAULT 2;
+
+  WHILE i <= 201 DO
+      INSERT INTO `user` (
+        id,
+        nickname,
+        email,
+        role,
+        user_status,
+        last_active_at,
+        created_at,
+        updated_at,
+        withdrawn_at
+      )
+      VALUES (
+               i,
+               CONCAT('testuser', LPAD(i, 4, '0')),
+               CONCAT('testuser', LPAD(i, 4, '0'), '@example.com'),
+               'USER',
+               'ACTIVE',
+               NOW(),
+               NOW(),
+               NOW(),
+               NULL
+             );
+      SET i = i + 1;
+    END WHILE;
+END$$
+
+DELIMITER ;
+
+CALL insert_users();
+DROP PROCEDURE insert_users;
+
+-- 다음 삽입을 위한 AUTO_INCREMENT 초기화
+ALTER TABLE `user` AUTO_INCREMENT = 202;

--- a/db/testdata/init_vote_responses.sql
+++ b/db/testdata/init_vote_responses.sql
@@ -1,0 +1,44 @@
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS insert_vote_responses$$
+
+CREATE PROCEDURE insert_vote_responses()
+BEGIN
+  DECLARE vote_id INT DEFAULT 1;
+  DECLARE user_id INT;
+  DECLARE vote_offset INT;
+
+  WHILE vote_id <= 100 DO
+      SET user_id = 2;
+      SET vote_offset = vote_id; -- vote_id에 따른 시간 보정용
+
+      WHILE user_id <= 201 DO
+          INSERT INTO vote_response (
+            vote_id,
+            user_id,
+            option_number,
+            voted_at
+          )
+          VALUES (
+                   vote_id,
+                   user_id,
+                   IF(RAND() < 0.5, 1, 2),
+                   IF(vote_id <= 50,
+                      DATE_SUB(NOW(), INTERVAL vote_offset HOUR), -- 과거 시간 (종료된 투표)
+                      DATE_SUB(NOW(), INTERVAL (100 - vote_offset) MINUTE) -- 진행 중 투표
+                   )
+                 );
+          SET user_id = user_id + 1;
+        END WHILE;
+
+      SET vote_id = vote_id + 1;
+    END WHILE;
+END$$
+
+DELIMITER ;
+
+CALL insert_vote_responses();
+DROP PROCEDURE insert_vote_responses;
+
+-- 다음 삽입을 위한 AUTO_INCREMENT 초기화
+ALTER TABLE vote_response AUTO_INCREMENT = 20001;

--- a/db/testdata/init_votes.sql
+++ b/db/testdata/init_votes.sql
@@ -1,0 +1,52 @@
+USE moa;
+
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS insert_votes$$
+
+CREATE PROCEDURE insert_votes()
+BEGIN
+  DECLARE i INT DEFAULT 1;
+
+  WHILE i <= 100 DO
+      INSERT INTO vote (
+        id,
+        user_id,
+        group_id,
+        content,
+        image_url,
+        closed_at,
+        anonymous,
+        vote_status,
+        admin_vote,
+        vote_type,
+        last_anonymous_number,
+        created_at,
+        updated_at
+      )
+      VALUES (
+               i,
+               1,  -- user_id
+               1,  -- group_id
+               CONCAT('Test Vote ', i),
+               NULL,
+               IF(i <= 50, NOW() - INTERVAL i HOUR, NOW() + INTERVAL i HOUR),
+               false,
+               'OPEN',
+               false,
+               'USER',
+               0,
+               NOW(),
+               NOW()
+             );
+      SET i = i + 1;
+    END WHILE;
+END$$
+
+DELIMITER ;
+
+CALL insert_votes();
+DROP PROCEDURE insert_votes;
+
+-- 다음 삽입을 위한 AUTO_INCREMENT 초기화
+ALTER TABLE vote AUTO_INCREMENT = 101;

--- a/db/testdata/truncate_all.sql
+++ b/db/testdata/truncate_all.sql
@@ -1,0 +1,5 @@
+USE moa;
+
+DELETE FROM vote_response;
+DELETE FROM vote;
+DELETE FROM `user` WHERE id != 1;

--- a/src/main/java/com/moa/moa_server/config/security/SecurityConstants.java
+++ b/src/main/java/com/moa/moa_server/config/security/SecurityConstants.java
@@ -9,6 +9,7 @@ public class SecurityConstants {
     "/swagger-ui/**",
     "v3/api-docs/**",
     "/swagger-resources/**",
-    "/webjars/**"
+    "/webjars/**",
+    "/test-login"
   };
 }

--- a/src/main/java/com/moa/moa_server/domain/test/controller/TestLoginController.java
+++ b/src/main/java/com/moa/moa_server/domain/test/controller/TestLoginController.java
@@ -1,0 +1,25 @@
+package com.moa.moa_server.domain.test.controller;
+
+import com.moa.moa_server.domain.auth.service.JwtTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test-login")
+@Profile("local")
+@RequiredArgsConstructor
+public class TestLoginController {
+
+  private final JwtTokenService jwtTokenService;
+
+  @PostMapping
+  public ResponseEntity<String> login(@RequestParam Long userId) {
+    String token = jwtTokenService.issueAccessToken(userId);
+    return ResponseEntity.ok(token);
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #126

## 🔥 작업 개요
- 테스트 시나리오 구성을 위한 더미 데이터 삽입 SQL 스크립트 추가
- 로컬 개발 및 성능 테스트 편의를 위한 테스트용 로그인 API 구현

## 🛠️ 작업 상세

### 1. 테스트용 SQL 스크립트 추가

- `scripts/db/testdata/` 디렉토리 내 SQL 파일 작성
    - `init_users.sql`: 테스트 유저 200명 생성
    - `init_votes.sql`: 투표 100개 생성
    - `init_vote_responses.sql`: 각 투표에 대해 사용자 200명이 랜덤 응답 생성 (총 응답 데이터 수 20,000개)
    - `truncate_all.sql`: 데이터 초기화를 위한 테이블 비우기 스크립트
- `README.md` 작성: 스크립트 실행 순서, 주의사항 정리
- 자동 실행되지 않도록 수동 실행 방식 유지 (`AUTO_INCREMENT` 포함)

### 2. 테스트용 로그인 API 구현

- 사용자 ID를 입력하면 JWT 토큰을 반환하는 테스트 전용 로그인 API 추가
- `local` 프로파일에서만 동작하도록 설정 (운영 환경 노출 방지)

## 🧪 테스트

- [x] SQL 스크립트 수동 실행 후 데이터 생성 확인
- [x] 테스트용 로그인 API 호출 시 JWT 발급 정상 동작 확인
- [x] 운영 환경 프로파일에서는 테스트 API 비활성화 확인

## 💬 기타 논의 사항
- ### **테스트 및 백업 목적을 위해 해당 브랜치는 삭제하지 않음 ‼️**