### PR TITLE
feat: 집계 테이블 기반 투표 API(V2) 및 목록 조회 API 구현

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -5,7 +5,7 @@
 ## 사용 방법
 
 1. 사전 조건
-   1. `user`, `vote`, `vote_response` 테이블이 생성되어 있어야 한다.
+   1. `user`, `vote`, `vote_response`, `vote_result` 테이블이 생성되어 있어야 한다.
    2. `init-data.sql`을 먼저 실행해, 기본 시스템 데이터가 생성되어 있어야 한다.
 2. MySQL 접속 후 `moa` 데이터베이스 선택
 3. 아래 순서로 실행
@@ -14,6 +14,7 @@
     source scripts/db/testdata/init_users.sql;
     source scripts/db/testdata/init_votes.sql;
     source scripts/db/testdata/init_vote_responses.sql;
+    source scripts/db/testdata/init_vote_results.sql;
 
 ## 주의 사항
 > 이 스크립트는 테스트 용도입니다. 프로덕션 환경에서는 절대 실행하지 마세요.

--- a/db/testdata/init_vote_responses.sql
+++ b/db/testdata/init_vote_responses.sql
@@ -1,3 +1,5 @@
+USE moa;
+
 DELIMITER $$
 
 DROP PROCEDURE IF EXISTS insert_vote_responses$$

--- a/db/testdata/init_vote_results.sql
+++ b/db/testdata/init_vote_results.sql
@@ -1,0 +1,28 @@
+USE moa;
+
+INSERT INTO vote_result (vote_id, option_number, count, ratio, created_at, updated_at)
+SELECT
+  vr.vote_id,
+  vr.option_number,
+  vr.count,
+  IFNULL(vr.count / total.total_count, 0.0) AS ratio,
+  NOW(),
+  NOW()
+FROM
+  (
+    SELECT
+      vote_id,
+      option_number,
+      COUNT(*) AS count
+    FROM vote_response
+    GROUP BY vote_id, option_number
+  ) vr
+    JOIN
+  (
+    SELECT
+      vote_id,
+      COUNT(*) AS total_count
+    FROM vote_response
+    WHERE option_number IN (1, 2)
+    GROUP BY vote_id
+  ) total ON vr.vote_id = total.vote_id;

--- a/db/testdata/truncate_all.sql
+++ b/db/testdata/truncate_all.sql
@@ -3,3 +3,4 @@ USE moa;
 DELETE FROM vote_response;
 DELETE FROM vote;
 DELETE FROM `user` WHERE id != 1;
+TRUNCATE TABLE vote_result;

--- a/src/main/java/com/moa/moa_server/config/security/LocalSecurityConfig.java
+++ b/src/main/java/com/moa/moa_server/config/security/LocalSecurityConfig.java
@@ -35,6 +35,10 @@ public class LocalSecurityConfig {
             auth ->
                 auth.requestMatchers(HttpMethod.GET, "/api/v1/votes")
                     .permitAll()
+                    .requestMatchers("/api/v2/votes/**")
+                    .permitAll()
+                    .requestMatchers("/test-login")
+                    .permitAll()
                     .requestMatchers(ALLOWED_URLS)
                     .permitAll()
                     .anyRequest()

--- a/src/main/java/com/moa/moa_server/config/security/SecurityConstants.java
+++ b/src/main/java/com/moa/moa_server/config/security/SecurityConstants.java
@@ -9,7 +9,6 @@ public class SecurityConstants {
     "/swagger-ui/**",
     "v3/api-docs/**",
     "/swagger-resources/**",
-    "/webjars/**",
-    "/test-login"
+    "/webjars/**"
   };
 }

--- a/src/main/java/com/moa/moa_server/domain/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/moa/moa_server/domain/global/handler/GlobalExceptionHandler.java
@@ -3,10 +3,12 @@ package com.moa.moa_server.domain.global.handler;
 import com.moa.moa_server.domain.global.dto.ApiResponse;
 import com.moa.moa_server.domain.global.exception.BaseException;
 import com.moa.moa_server.domain.global.exception.GlobalErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -17,6 +19,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiResponse<Void>> handleUnhandled(Exception ex) {
+    log.error("Unhandled Exception Occurred", ex);
     return ResponseEntity.status(500)
         .body(new ApiResponse<>(GlobalErrorCode.UNEXPECTED_ERROR.name(), null));
   }

--- a/src/main/java/com/moa/moa_server/domain/test/controller/TestLoginController.java
+++ b/src/main/java/com/moa/moa_server/domain/test/controller/TestLoginController.java
@@ -1,6 +1,7 @@
 package com.moa.moa_server.domain.test.controller;
 
 import com.moa.moa_server.domain.auth.service.JwtTokenService;
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden
 @RestController
 @RequestMapping("/test-login")
 @Profile("local")

--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteControllerV2.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteControllerV2.java
@@ -1,0 +1,28 @@
+package com.moa.moa_server.domain.vote.controller;
+
+import com.moa.moa_server.domain.global.dto.ApiResponse;
+import com.moa.moa_server.domain.vote.dto.request.VoteSubmitRequest;
+import com.moa.moa_server.domain.vote.service.VoteServiceV2;
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v2/votes")
+@RequiredArgsConstructor
+public class VoteControllerV2 {
+
+  private final VoteServiceV2 voteServiceV2;
+
+  @Hidden
+  @PostMapping("/{voteId}/submit")
+  public ResponseEntity<ApiResponse<Void>> submitVote(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long voteId,
+      @RequestBody VoteSubmitRequest request) {
+    voteServiceV2.submitVote(voteId, userId, request);
+    return ResponseEntity.ok(new ApiResponse<>("SUCCESS", null));
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteControllerV2.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteControllerV2.java
@@ -2,6 +2,7 @@ package com.moa.moa_server.domain.vote.controller;
 
 import com.moa.moa_server.domain.global.dto.ApiResponse;
 import com.moa.moa_server.domain.vote.dto.request.VoteSubmitRequest;
+import com.moa.moa_server.domain.vote.dto.response.submitted.SubmittedVoteResponse;
 import com.moa.moa_server.domain.vote.service.VoteServiceV2;
 import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
@@ -24,5 +25,16 @@ public class VoteControllerV2 {
       @RequestBody VoteSubmitRequest request) {
     voteServiceV2.submitVote(voteId, userId, request);
     return ResponseEntity.ok(new ApiResponse<>("SUCCESS", null));
+  }
+
+  @Hidden
+  @GetMapping("/submit")
+  public ResponseEntity<ApiResponse<SubmittedVoteResponse>> getSubmittedVotes(
+      @AuthenticationPrincipal Long userId,
+      @RequestParam(required = false) Long groupId,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) Integer size) {
+    SubmittedVoteResponse response = voteServiceV2.getSubmittedVotes(userId, groupId, cursor, size);
+    return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/handler/VoteErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/handler/VoteErrorCode.java
@@ -16,7 +16,7 @@ public enum VoteErrorCode implements BaseErrorCode {
   VOTE_NOT_OPENED(HttpStatus.FORBIDDEN),
   INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST),
   INVALID_MODERATION_RESULT(HttpStatus.BAD_REQUEST),
-  ;
+  RESULT_UPDATE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR);
 
   private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResultRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResultRepository.java
@@ -1,6 +1,7 @@
 package com.moa.moa_server.domain.vote.repository;
 
 import com.moa.moa_server.domain.vote.entity.VoteResult;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -16,4 +17,6 @@ public interface VoteResultRepository extends JpaRepository<VoteResult, Long> {
     WHERE v.vote.id = :voteId AND v.optionNumber = :optionNumber
   """)
   int incrementOptionCount(@Param("voteId") Long voteId, @Param("optionNumber") int optionNumber);
+
+  List<VoteResult> findAllByVoteId(Long voteId);
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResultRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResultRepository.java
@@ -2,5 +2,18 @@ package com.moa.moa_server.domain.vote.repository;
 
 import com.moa.moa_server.domain.vote.entity.VoteResult;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface VoteResultRepository extends JpaRepository<VoteResult, Long> {}
+public interface VoteResultRepository extends JpaRepository<VoteResult, Long> {
+
+  @Modifying
+  @Query(
+      """
+    UPDATE VoteResult v
+    SET v.count = v.count + 1
+    WHERE v.vote.id = :voteId AND v.optionNumber = :optionNumber
+  """)
+  int incrementOptionCount(@Param("voteId") Long voteId, @Param("optionNumber") int optionNumber);
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -27,10 +27,12 @@ import com.moa.moa_server.domain.vote.dto.response.submitted.SubmittedVoteItem;
 import com.moa.moa_server.domain.vote.dto.response.submitted.SubmittedVoteResponse;
 import com.moa.moa_server.domain.vote.entity.Vote;
 import com.moa.moa_server.domain.vote.entity.VoteResponse;
+import com.moa.moa_server.domain.vote.entity.VoteResult;
 import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
 import com.moa.moa_server.domain.vote.handler.VoteException;
 import com.moa.moa_server.domain.vote.repository.VoteRepository;
 import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
+import com.moa.moa_server.domain.vote.repository.VoteResultRepository;
 import com.moa.moa_server.domain.vote.util.VoteValidator;
 import jakarta.annotation.Nullable;
 import java.time.LocalDateTime;
@@ -61,6 +63,7 @@ public class VoteService {
   private final GroupRepository groupRepository;
   private final GroupMemberRepository groupMemberRepository;
   private final VoteResponseRepository voteResponseRepository;
+  private final VoteResultRepository voteResultRepository;
 
   private final GroupService groupService;
   private final VoteResultService voteResultService;
@@ -120,6 +123,11 @@ public class VoteService {
             status,
             adminVote);
     voteRepository.save(vote);
+
+    // 옵션별 초기 결과 생성
+    VoteResult result1 = VoteResult.createInitial(vote, 1);
+    VoteResult result2 = VoteResult.createInitial(vote, 2);
+    voteResultRepository.saveAll(List.of(result1, result2));
 
     // AI 서버로 검열 요청 (prod 환경에서만)
     if ("prod".equals(activeProfile)) {

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteServiceV2.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteServiceV2.java
@@ -1,0 +1,91 @@
+package com.moa.moa_server.domain.vote.service;
+
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.handler.UserErrorCode;
+import com.moa.moa_server.domain.user.handler.UserException;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.user.util.AuthUserValidator;
+import com.moa.moa_server.domain.vote.dto.request.VoteSubmitRequest;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.entity.VoteResponse;
+import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
+import com.moa.moa_server.domain.vote.handler.VoteException;
+import com.moa.moa_server.domain.vote.repository.VoteRepository;
+import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
+import com.moa.moa_server.domain.vote.repository.VoteResultRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class VoteServiceV2 {
+
+  private final VoteResponseRepository voteResponseRepository;
+  private final VoteResultRepository voteResultRepository;
+  private final VoteRepository voteRepository;
+  private final UserRepository userRepository;
+  private final GroupMemberRepository groupMemberRepository;
+
+  @Transactional
+  public void submitVote(Long voteId, Long userId, VoteSubmitRequest request) {
+    // 유저 조회 및 유효성 검사
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    AuthUserValidator.validateActive(user);
+
+    // 응답 값 유효성 검증
+    int response = request.userResponse();
+    if (response < 0 || response > 2) {
+      throw new VoteException(VoteErrorCode.INVALID_OPTION);
+    }
+
+    // 투표 조회
+    Vote vote =
+        voteRepository
+            .findById(voteId)
+            .orElseThrow(() -> new VoteException(VoteErrorCode.VOTE_NOT_FOUND));
+
+    // 투표 상태 체크
+    if (!vote.isOpen()) {
+      throw new VoteException(VoteErrorCode.VOTE_NOT_OPENED);
+    }
+
+    // 투표 권한 조회
+    Group group = vote.getGroup();
+    if (!group.isPublicGroup()) {
+      boolean isGroupMember = groupMemberRepository.findByGroupAndUser(group, user).isPresent();
+
+      if (!isGroupMember) {
+        throw new VoteException(VoteErrorCode.NOT_GROUP_MEMBER);
+      }
+    }
+
+    // 중복 투표 확인
+    if (voteResponseRepository.existsByVoteAndUser(vote, user)) {
+      throw new VoteException(VoteErrorCode.ALREADY_VOTED);
+    }
+
+    // 1. 응답 저장
+    VoteResponse voteResponse = VoteResponse.create(vote, user, response);
+    try {
+      voteResponseRepository.save(voteResponse);
+    } catch (DataIntegrityViolationException e) {
+      throw new VoteException(VoteErrorCode.ALREADY_VOTED);
+    }
+
+    // 2. 집계 테이블 업데이트
+    if (response == 1 || response == 2) {
+      int updated = voteResultRepository.incrementOptionCount(voteId, response);
+      if (updated != 1) {
+        throw new VoteException(VoteErrorCode.RESULT_UPDATE_FAIL);
+      }
+    }
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteServiceV2.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteServiceV2.java
@@ -1,13 +1,19 @@
 package com.moa.moa_server.domain.vote.service;
 
+import com.moa.moa_server.domain.global.cursor.ClosedAtVoteIdCursor;
 import com.moa.moa_server.domain.group.entity.Group;
 import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
+import com.moa.moa_server.domain.group.repository.GroupRepository;
+import com.moa.moa_server.domain.group.service.GroupService;
 import com.moa.moa_server.domain.user.entity.User;
 import com.moa.moa_server.domain.user.handler.UserErrorCode;
 import com.moa.moa_server.domain.user.handler.UserException;
 import com.moa.moa_server.domain.user.repository.UserRepository;
 import com.moa.moa_server.domain.user.util.AuthUserValidator;
 import com.moa.moa_server.domain.vote.dto.request.VoteSubmitRequest;
+import com.moa.moa_server.domain.vote.dto.response.VoteOptionResultWithId;
+import com.moa.moa_server.domain.vote.dto.response.submitted.SubmittedVoteItem;
+import com.moa.moa_server.domain.vote.dto.response.submitted.SubmittedVoteResponse;
 import com.moa.moa_server.domain.vote.entity.Vote;
 import com.moa.moa_server.domain.vote.entity.VoteResponse;
 import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
@@ -15,6 +21,8 @@ import com.moa.moa_server.domain.vote.handler.VoteException;
 import com.moa.moa_server.domain.vote.repository.VoteRepository;
 import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
 import com.moa.moa_server.domain.vote.repository.VoteResultRepository;
+import jakarta.annotation.Nullable;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -25,11 +33,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class VoteServiceV2 {
 
+  private static final int DEFAULT_PAGE_SIZE = 10;
+
   private final VoteResponseRepository voteResponseRepository;
   private final VoteResultRepository voteResultRepository;
   private final VoteRepository voteRepository;
   private final UserRepository userRepository;
   private final GroupMemberRepository groupMemberRepository;
+  private final GroupRepository groupRepository;
+
+  private final GroupService groupService;
 
   @Transactional
   public void submitVote(Long voteId, Long userId, VoteSubmitRequest request) {
@@ -87,5 +100,74 @@ public class VoteServiceV2 {
         throw new VoteException(VoteErrorCode.RESULT_UPDATE_FAIL);
       }
     }
+  }
+
+  @Transactional(readOnly = true)
+  public SubmittedVoteResponse getSubmittedVotes(
+      Long userId, @Nullable Long groupId, @Nullable String cursor, @Nullable Integer size) {
+
+    int pageSize = (size == null || size <= 0) ? DEFAULT_PAGE_SIZE : size;
+    ClosedAtVoteIdCursor parsedCursor = cursor != null ? ClosedAtVoteIdCursor.parse(cursor) : null;
+    if (cursor != null && !voteRepository.existsById(parsedCursor.voteId())) {
+      throw new VoteException(VoteErrorCode.VOTE_NOT_FOUND);
+    }
+
+    // 유저 조회 및 검증
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    AuthUserValidator.validateActive(user);
+
+    // 조회 대상 그룹 목록 수집
+    List<Group> groups;
+    if (groupId != null) {
+      // 특정 그룹이 지정된 경우
+      Group group =
+          groupRepository
+              .findById(groupId)
+              .orElseThrow(() -> new VoteException(VoteErrorCode.GROUP_NOT_FOUND));
+      groups = List.of(group);
+    } else {
+      // 전체 그룹 조회: 유저가 속한 그룹 + 공개 그룹
+      groups = groupMemberRepository.findAllActiveGroupsByUser(user);
+      Group publicGroup = groupService.getPublicGroup();
+      if (!groups.contains(publicGroup)) {
+        groups.add(publicGroup);
+      }
+    }
+
+    // 참여한 투표 목록 조회
+    List<Vote> votes = voteRepository.findSubmittedVotes(user, groups, parsedCursor, pageSize + 1);
+
+    // 응답 구성
+    boolean hasNext = votes.size() > pageSize;
+    if (hasNext) votes = votes.subList(0, pageSize);
+
+    String nextCursor =
+        votes.isEmpty()
+            ? null
+            : new ClosedAtVoteIdCursor(votes.getLast().getClosedAt(), votes.getLast().getId())
+                .encode();
+
+    // 각 투표별 집계 결과를 포함한 응답 DTO 구성
+    List<SubmittedVoteItem> items =
+        votes.stream()
+            .map(
+                vote -> {
+                  var results =
+                      voteResultRepository.findAllByVoteId(vote.getId()).stream()
+                          .map(
+                              vr ->
+                                  new VoteOptionResultWithId(
+                                      vote.getId(),
+                                      vr.getOptionNumber(),
+                                      vr.getCount(),
+                                      vr.getRatio().doubleValue()))
+                          .toList();
+                  return SubmittedVoteItem.from(vote, results);
+                })
+            .toList();
+    return new SubmittedVoteResponse(items, nextCursor, hasNext, items.size());
   }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -2,7 +2,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
+#    show-sql: true
     properties:
       hibernate:
         format_sql: true
@@ -28,5 +28,8 @@ mock:
 
 logging:
   level:
+    root: INFO
+    org.springframework.web: DEBUG
     org.springframework.security: DEBUG
-    org.hibernate.type.descriptor.sql: trace
+    org.springframework.web.filter: DEBUG
+#    org.hibernate.type.descriptor.sql: trace


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #128

## 🔥 작업 개요
- Redis 도입 전, 기존 실시간 집계 방식과의 성능 비교를 위한  
  **집계 테이블 기반 투표 API(V2)** 구현

## 🛠️ 작업 상세

### 1. 집계 테이블 기반 투표 참여 API(V2) 구현

- `POST /api/v2/votes/{voteId}/submit`
- `vote_response` 저장 후, `vote_result` 테이블의 해당 옵션 count를 `+1` 증가
- `count = count + 1` 형태의 **DB 원자 연산 쿼리**를 사용하여,  
  **동시성 환경에서도 정확한 집계가 이루어지도록 구현**

### 2. 참여한 투표 목록 조회 API(V2) 구현

- `GET /api/v2/votes/submit`
- 기존 방식은 실시간 COUNT 쿼리를 통해 집계 정보를 계산
- V2에서는 `vote_result` 테이블의 count 및 ratio 값을 조회하여 집계 결과 반환

### 3. 기타 보완

- 투표 등록 시 `vote_result` 초기화 쿼리 추가 (옵션 1, 2 기준으로 row 생성)


## 🧪 테스트

- [x] 테스트용 투표 100개, 응답 2만 개 삽입 후 정확한 집계 확인
- [x] `vote_response` 수와 `vote_result` count 합계가 일치하는지 검증
- [x] Locust로 200명 동시 투표 요청 시 동시성 문제 없음
- [x] 참여한 투표 목록 API에서 집계 결과 정확히 노출됨 확인

## 💬 기타 논의 사항
- Redis 기반 집계 방식(V3) 구현을 위한 기준선 확보 완료
- 실시간 집계 vs 집계 테이블 방식 간 성능 차이 측정 가능
- ###  **테스트 및 비교 실험 목적의 브랜치이므로 삭제하지 않음‼️**