### PR TITLE
feat: Prometheus 메트릭 수집을 위한 Actuator 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+  // Prometheus / Micrometer
+  implementation 'org.springframework.boot:spring-boot-starter-actuator'
+  implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 spotless {

--- a/src/main/java/com/moa/moa_server/config/security/SecurityConstants.java
+++ b/src/main/java/com/moa/moa_server/config/security/SecurityConstants.java
@@ -9,6 +9,7 @@ public class SecurityConstants {
     "/swagger-ui/**",
     "v3/api-docs/**",
     "/swagger-resources/**",
-    "/webjars/**"
+    "/webjars/**",
+    "/actuator/prometheus"
   };
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,3 +9,9 @@ kakao:
   token-uri: https://kauth.kakao.com/oauth/token
   user-info-uri: https://kapi.kakao.com/v2/user/me
   unlink-uri: https://kapi.kakao.com/v1/user/unlink
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #138

## 🔥 작업 개요

- Prometheus 메트릭 수집을 위한 Actuator 및 Micrometer 설정
- /actuator/prometheus 엔드포인트 활성화 

## 🧪 테스트
- [x]  /actuator/prometheus 요청 시 200 OK 응답 확인
- [x]  Prometheus 포맷의 메트릭 정상 출력 확인
- [x]  Spring Security 설정 적용 상태에서 인증 없이 접근 가능한지 확인


## 💬 기타 논의 사항
- 없음
