### PR TITLE
feat: 투표 종료 시각 유효성 검사에 +7일 제한 추가 (#107)

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/vote/util/VoteValidator.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/util/VoteValidator.java
@@ -22,7 +22,9 @@ public class VoteValidator {
   }
 
   public static void validateClosedAt(LocalDateTime closedAt) {
-    if (closedAt == null || !closedAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
+    LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+
+    if (closedAt == null || !closedAt.isAfter(now) || closedAt.isAfter(now.plusDays(7))) {
       throw new VoteException(VoteErrorCode.INVALID_TIME);
     }
   }


### PR DESCRIPTION
## 📌 관련 이슈

* Closes #107

## 🔥 작업 개요

* 투표 종료 시각(closedAt)에 대한 유효성 검사 로직 추가
* 현재 시각 이후이며, 최대 7일 이내만 허용되도록 제한

## 🧪 테스트

* [x] 현재 시각 + 8일 이상 입력 시 예외 발생 확인
* [x] 현재 시각 + 7일 이내 입력 시 정상 처리 확인

## 💬 기타 논의 사항

* 없음