### PR TITLE
hotfix: v1.3.1

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/global/util/XssUtil.java
+++ b/src/main/java/com/moa/moa_server/domain/global/util/XssUtil.java
@@ -5,10 +5,23 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class XssUtil {
-  private static final XssFilter xssFilter = XssFilter.getInstance("lucy-xss-superset.xml");
+  private static final XssFilter xssFilter = XssFilter.getInstance("lucy-xss-superset.xml", true);
 
   public static String sanitize(String input) {
     if (input == null) return null;
-    return xssFilter.doFilter(input);
+    String filtered = xssFilter.doFilter(input);
+
+    // 위험한 태그 escape 형태 감지
+    boolean hasDangerousTag =
+        filtered.matches(
+            "(?i).*&lt;\\s*/?\\s*(script|iframe|style|object|embed|img|meta|link|base)\\b[^&]*&gt;.*");
+
+    if (hasDangerousTag) {
+      // 위험한 태그가 있으면 그대로 escape 상태 유지
+      return filtered;
+    } else {
+      // 위험한 태그 없으면 <, > 복원
+      return filtered.replace("&lt;", "<").replace("&gt;", ">");
+    }
   }
 }

--- a/src/main/resources/lucy-xss-superset.xml
+++ b/src/main/resources/lucy-xss-superset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- version 20180725-1 -->
 <config xmlns="http://www.nhncorp.com/lucy-xss">
-	<denyTagComment>false</denyTagComment>
+	<denyTagComment>true</denyTagComment>
 	<elementRule>
 		<element name="body" disable="true" /> <!-- <BODY ONLOAD=alert("XSS")>, <BODY BACKGROUND="javascript:alert('XSS')"> -->
 		<element name="embed" disable="true" />

--- a/src/test/java/com/moa/moa_server/domain/global/util/XssUtilTest.java
+++ b/src/test/java/com/moa/moa_server/domain/global/util/XssUtilTest.java
@@ -1,0 +1,50 @@
+package com.moa.moa_server.domain.global.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class XssUtilTest {
+  @Test
+  @DisplayName("일반 기호는 그대로 출력됨")
+  void testNormalSymbolsRemain() {
+    String input = "<<배고픈 사람>>";
+    String result = XssUtil.sanitize(input);
+    assertEquals("<<배고픈 사람>>", result);
+  }
+
+  @Test
+  @DisplayName("script 태그는 escape 되어야 함")
+  void testScriptTagFiltered() {
+    String input = "<script>alert('XSS')</script>";
+    String result = XssUtil.sanitize(input);
+    assertTrue(result.contains("&lt;script&gt;"));
+    assertFalse(result.contains("<script>"));
+  }
+
+  @Test
+  @DisplayName("iframe 태그도 escape 되어야 함")
+  void testIframeTagFiltered() {
+    String input = "<iframe src='evil.com'></iframe>";
+    String result = XssUtil.sanitize(input);
+    assertTrue(result.contains("&lt;iframe"));
+  }
+
+  @Test
+  @DisplayName("HTML 태그 없이 부등호만 있을 경우 복원")
+  void testNoTagButHasAngleBrackets() {
+    String input = "이쪽 >> 저쪽";
+    String result = XssUtil.sanitize(input);
+    assertEquals("이쪽 >> 저쪽", result);
+  }
+
+  @Test
+  @DisplayName("HTML 속성 삽입 시도 방지")
+  void testAttributeInjection() {
+    String input = "<img src='javascript:alert(1)'>";
+    String result = XssUtil.sanitize(input);
+    assertTrue(result.contains("javascript"));
+    assertTrue(result.contains("&lt;img")); // 태그 자체는 escape
+  }
+}


### PR DESCRIPTION
## 목적
- XSS 필터 개선: `<`, `>` 표현 복원

## 관련 이슈
- Closes #144 

## 내용
1. 사용자 표현을 위한 `<`, `<<`, `>>>` 등의 기호 복원 로직 추가
   - 기존 Lucy XSS 필터는 모든 `<`, `>` 문자를 `&lt;`, `&gt;`로 escape 처리함
   - 사용자 입력이 단순 기호일 경우 복원하여 의도대로 표시되도록 처리
   - 위험한 태그(`<script>`, `<iframe>`, 등)는 여전히 escape 상태 유지
     - 정규식을 이용해 `<태그명>` 형태가 포함된 경우 복원하지 않음
2. 관련 테스트 코드 추가
   - XSS 필터링 및 복원 로직에 대한 단위 테스트 작성
   - 실제 태그와 단순 표현 기호 간 구분이 잘 되는지 검증
3. 기본 설정 주석 제거
    - html 태그 감지 시 데이터에 삽입되는 주석 제거 설정 → 메모리 사용량 5% 감소 [(ref)](https://naver.github.io/lucy-xss-filter/kr/#_%EC%84%A4%EC%A0%95_%ED%8C%8C%EC%9D%BC:~:text=%EB%A9%94%EB%AA%A8%EB%A6%AC%20%EC%82%AC%EC%9A%A9%EB%9F%89%EC%9D%84%20%EC%95%BD%205%25%20%EC%A4%84%EC%9D%BC%20%EC%88%98%20%EC%9E%88%EB%8B%A4.)