### PR TITLE
test: VoteService 투표 등록/참여/상세/결과/목록 단위 테스트 코드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+  testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
   // Prometheus / Micrometer

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -32,7 +32,6 @@ import com.moa.moa_server.domain.vote.handler.VoteException;
 import com.moa.moa_server.domain.vote.model.VoteWithVotedAt;
 import com.moa.moa_server.domain.vote.repository.VoteRepository;
 import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
-import com.moa.moa_server.domain.vote.repository.VoteResultRepository;
 import com.moa.moa_server.domain.vote.service.vote_result.VoteResultRedisService;
 import com.moa.moa_server.domain.vote.service.vote_result.VoteResultService;
 import com.moa.moa_server.domain.vote.util.VoteValidator;
@@ -66,7 +65,6 @@ public class VoteService {
   private final GroupRepository groupRepository;
   private final GroupMemberRepository groupMemberRepository;
   private final VoteResponseRepository voteResponseRepository;
-  private final VoteResultRepository voteResultRepository;
 
   private final GroupService groupService;
   private final VoteResultService voteResultService;

--- a/src/test/java/com/moa/moa_server/MoaServerApplicationTests.java
+++ b/src/test/java/com/moa/moa_server/MoaServerApplicationTests.java
@@ -5,7 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("local")
+@ActiveProfiles("test")
 class MoaServerApplicationTests {
 
   @Test

--- a/src/test/java/com/moa/moa_server/unit/global/util/XssUtilTest.java
+++ b/src/test/java/com/moa/moa_server/unit/global/util/XssUtilTest.java
@@ -1,7 +1,8 @@
-package com.moa.moa_server.domain.global.util;
+package com.moa.moa_server.unit.global.util;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.moa.moa_server.domain.global.util.XssUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/moa/moa_server/unit/vote/service/VoteActiveListTest.java
+++ b/src/test/java/com/moa/moa_server/unit/vote/service/VoteActiveListTest.java
@@ -5,15 +5,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
 import com.moa.moa_server.domain.group.repository.GroupRepository;
 import com.moa.moa_server.domain.user.entity.User;
 import com.moa.moa_server.domain.user.repository.UserRepository;
 import com.moa.moa_server.domain.vote.dto.response.active.ActiveVoteResponse;
 import com.moa.moa_server.domain.vote.entity.Vote;
 import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
+import com.moa.moa_server.domain.vote.handler.VoteException;
 import com.moa.moa_server.domain.vote.repository.VoteRepository;
-import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
 import com.moa.moa_server.domain.vote.service.VoteService;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -31,9 +33,9 @@ public class VoteActiveListTest {
   @InjectMocks private VoteService voteService;
 
   @Mock private VoteRepository voteRepository;
-  @Mock private VoteResponseRepository voteResponseRepository;
   @Mock private UserRepository userRepository;
   @Mock private GroupRepository groupRepository;
+  @Mock private GroupMemberRepository groupMemberRepository;
 
   @Mock private User user;
   @Mock private Vote vote;
@@ -89,8 +91,123 @@ public class VoteActiveListTest {
   }
 
   @Nested
-  class 로그인_성공_케이스 {}
+  class 로그인_성공_케이스 {
+    @Test
+    @DisplayName("로그인 사용자, 공개 그룹 투표 리스트 정상 조회")
+    void getActiveVotes_authenticated_success() {
+      // given
+      Long userId = 42L;
+      Long groupId = 1L;
+
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+      when(user.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+
+      when(group.isPublicGroup()).thenReturn(true);
+      when(group.getId()).thenReturn(groupId);
+      when(groupRepository.findById(groupId)).thenReturn(Optional.of(group));
+
+      // 사용자의 접근 가능한 그룹이 공개 그룹만 있다고 가정
+      when(voteRepository.findActiveVotes(eq(List.of(group)), any(), eq(user), anyInt()))
+          .thenReturn(List.of(vote));
+
+      // 반환되는 투표 객체
+      when(vote.getId()).thenReturn(100L);
+      when(vote.getGroup()).thenReturn(group);
+      when(vote.getUser()).thenReturn(user);
+      when(vote.getVoteType()).thenReturn(Vote.VoteType.USER);
+      when(user.getNickname()).thenReturn("testUser");
+      when(vote.getClosedAt()).thenReturn(LocalDateTime.now().plusDays(1));
+      when(vote.getCreatedAt()).thenReturn(LocalDateTime.now().minusDays(1));
+
+      // when
+      ActiveVoteResponse result = voteService.getActiveVotes(userId, groupId, null, null);
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.votes()).hasSize(1);
+      assertThat(result.votes().getFirst().voteId()).isEqualTo(100L);
+      assertThat(result.votes().getFirst().groupId()).isEqualTo(groupId);
+      assertThat(result.votes().getFirst().authorNickname()).isEqualTo("testUser");
+    }
+
+    @Test
+    @DisplayName("로그인 사용자, 비공개 그룹 투표 리스트 정상 조회")
+    void getActiveVotes_authenticated_privateGroup_success() {
+      // given
+      Long userId = 42L;
+      Long groupId = 2L;
+
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+      when(user.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+
+      // 비공개 그룹 세팅
+      when(group.isPublicGroup()).thenReturn(false);
+      when(group.getId()).thenReturn(groupId);
+      when(groupRepository.findById(groupId)).thenReturn(Optional.of(group));
+
+      // 그룹 멤버 세팅
+      when(groupMemberRepository.findByGroupAndUser(group, user))
+          .thenReturn(Optional.of(mock(com.moa.moa_server.domain.group.entity.GroupMember.class)));
+
+      // 투표 데이터 (해당 그룹의 투표 1개)
+      when(voteRepository.findActiveVotes(eq(List.of(group)), any(), eq(user), anyInt()))
+          .thenReturn(List.of(vote));
+
+      when(vote.getId()).thenReturn(101L);
+      when(vote.getGroup()).thenReturn(group);
+      when(vote.getUser()).thenReturn(user);
+      when(vote.getVoteType()).thenReturn(Vote.VoteType.USER);
+      when(user.getNickname()).thenReturn("privateUser");
+      when(vote.getClosedAt()).thenReturn(LocalDateTime.now().plusDays(1));
+      when(vote.getCreatedAt()).thenReturn(LocalDateTime.now().minusDays(1));
+
+      // when
+      ActiveVoteResponse result = voteService.getActiveVotes(userId, groupId, null, null);
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.votes()).hasSize(1);
+      assertThat(result.votes().getFirst().voteId()).isEqualTo(101L);
+      assertThat(result.votes().getFirst().groupId()).isEqualTo(groupId);
+      assertThat(result.votes().getFirst().authorNickname()).isEqualTo("privateUser");
+    }
+  }
 
   @Nested
-  class 로그인_실패_케이스 {}
+  class 로그인_실패_케이스 {
+    @Test
+    @DisplayName("비공개 그룹인데 멤버가 아닌 경우 FORBIDDEN 예외")
+    void getActiveVotes_authenticated_privateGroup_notMember_forbidden() {
+      // given
+      Long userId = 42L;
+      Long groupId = 2L;
+
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+      when(user.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+
+      when(group.isPublicGroup()).thenReturn(false);
+      when(groupRepository.findById(groupId)).thenReturn(Optional.of(group));
+
+      // when & then
+      assertThatThrownBy(() -> voteService.getActiveVotes(userId, groupId, null, null))
+          .isInstanceOf(VoteException.class)
+          .hasMessageContaining(VoteErrorCode.FORBIDDEN.name());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 그룹 id로 요청 시 GROUP_NOT_FOUND 예외")
+    void getActiveVotes_authenticated_groupNotFound() {
+      // given
+      Long userId = 42L;
+      Long groupId = 999L;
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+      when(user.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+      when(groupRepository.findById(groupId)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> voteService.getActiveVotes(userId, groupId, null, null))
+          .isInstanceOf(com.moa.moa_server.domain.vote.handler.VoteException.class)
+          .hasMessageContaining(VoteErrorCode.GROUP_NOT_FOUND.name());
+    }
+  }
 }

--- a/src/test/java/com/moa/moa_server/unit/vote/service/VoteActiveListTest.java
+++ b/src/test/java/com/moa/moa_server/unit/vote/service/VoteActiveListTest.java
@@ -1,0 +1,96 @@
+package com.moa.moa_server.unit.vote.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.repository.GroupRepository;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.vote.dto.response.active.ActiveVoteResponse;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
+import com.moa.moa_server.domain.vote.repository.VoteRepository;
+import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
+import com.moa.moa_server.domain.vote.service.VoteService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VoteService#getActiveVoteList")
+public class VoteActiveListTest {
+
+  @InjectMocks private VoteService voteService;
+
+  @Mock private VoteRepository voteRepository;
+  @Mock private VoteResponseRepository voteResponseRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private GroupRepository groupRepository;
+
+  @Mock private User user;
+  @Mock private Vote vote;
+  @Mock private Group group;
+
+  @Nested
+  class 비로그인_성공_케이스 {
+    @Test
+    @DisplayName("공개 그룹 투표 리스트 정상 조회")
+    void getActiveVotes_unauthenticated_success() {
+      // given
+      when(group.isPublicGroup()).thenReturn(true);
+      when(group.getId()).thenReturn(1L);
+      when(groupRepository.findById(1L)).thenReturn(Optional.of(group));
+      when(voteRepository.findActiveVotes(
+              eq(List.of(group)),
+              any(), // cursor
+              isNull(), // user
+              anyInt()))
+          .thenReturn(List.of(vote));
+      when(vote.getId()).thenReturn(10L);
+      when(vote.getGroup()).thenReturn(group);
+      when(vote.getUser()).thenReturn(user);
+      when(vote.getVoteType()).thenReturn(Vote.VoteType.USER);
+      when(user.getNickname()).thenReturn("test");
+
+      // when
+      ActiveVoteResponse result = voteService.getActiveVotes(null, 1L, null, null);
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.votes()).hasSize(1); // 투표 1개만 반환됨을 검증
+      assertThat(result.votes().getFirst().voteId()).isEqualTo(10L); // 반환된 투표의 ID가 10인지 확인
+      assertThat(result.votes().getFirst().groupId()).isEqualTo(1L); // groupId가 1인지 확인
+    }
+  }
+
+  @Nested
+  class 비로그인_실패_케이스 {
+    @Test
+    @DisplayName("비공개 그룹 접근 시 403")
+    void getActiveVotes_unauthenticated_privateGroup_forbidden() {
+      // given
+      Group privateGroup = mock(Group.class);
+      when(privateGroup.isPublicGroup()).thenReturn(false);
+      when(groupRepository.findById(1L)).thenReturn(Optional.of(privateGroup));
+
+      // when & then
+      assertThatThrownBy(() -> voteService.getActiveVotes(null, 1L, null, null))
+          .isInstanceOf(com.moa.moa_server.domain.vote.handler.VoteException.class)
+          .hasMessageContaining(VoteErrorCode.FORBIDDEN.name());
+    }
+  }
+
+  @Nested
+  class 로그인_성공_케이스 {}
+
+  @Nested
+  class 로그인_실패_케이스 {}
+}

--- a/src/test/java/com/moa/moa_server/unit/vote/service/VoteCreateTest.java
+++ b/src/test/java/com/moa/moa_server/unit/vote/service/VoteCreateTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.*;
 import com.moa.moa_server.domain.group.entity.Group;
 import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
 import com.moa.moa_server.domain.group.repository.GroupRepository;
-import com.moa.moa_server.domain.group.service.GroupService;
 import com.moa.moa_server.domain.user.entity.User;
 import com.moa.moa_server.domain.user.repository.UserRepository;
 import com.moa.moa_server.domain.vote.dto.request.VoteCreateRequest;
@@ -16,11 +15,8 @@ import com.moa.moa_server.domain.vote.entity.Vote;
 import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
 import com.moa.moa_server.domain.vote.handler.VoteException;
 import com.moa.moa_server.domain.vote.repository.VoteRepository;
-import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
-import com.moa.moa_server.domain.vote.service.VoteModerationService;
 import com.moa.moa_server.domain.vote.service.VoteService;
 import com.moa.moa_server.domain.vote.service.vote_result.VoteResultRedisService;
-import com.moa.moa_server.domain.vote.service.vote_result.VoteResultService;
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -44,14 +40,10 @@ public class VoteCreateTest {
   @InjectMocks private VoteService voteService;
 
   @Mock private VoteRepository voteRepository;
-  @Mock private VoteResponseRepository voteResponseRepository;
   @Mock private UserRepository userRepository;
   @Mock private GroupRepository groupRepository;
   @Mock private VoteResultRedisService voteResultRedisService;
   @Mock private GroupMemberRepository groupMemberRepository;
-  @Mock private VoteResultService voteResultService;
-  @Mock private GroupService groupService;
-  @Mock private VoteModerationService voteModerationService;
 
   @Mock private User user;
   @Mock private Group group;

--- a/src/test/java/com/moa/moa_server/unit/vote/service/VoteCreateTest.java
+++ b/src/test/java/com/moa/moa_server/unit/vote/service/VoteCreateTest.java
@@ -1,0 +1,175 @@
+package com.moa.moa_server.unit.vote.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
+import com.moa.moa_server.domain.group.repository.GroupRepository;
+import com.moa.moa_server.domain.group.service.GroupService;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.vote.dto.request.VoteCreateRequest;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
+import com.moa.moa_server.domain.vote.handler.VoteException;
+import com.moa.moa_server.domain.vote.repository.VoteRepository;
+import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
+import com.moa.moa_server.domain.vote.service.VoteModerationService;
+import com.moa.moa_server.domain.vote.service.VoteService;
+import com.moa.moa_server.domain.vote.service.vote_result.VoteResultRedisService;
+import com.moa.moa_server.domain.vote.service.vote_result.VoteResultService;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VoteService#createVote")
+public class VoteCreateTest {
+
+  @InjectMocks private VoteService voteService;
+
+  @Mock private VoteRepository voteRepository;
+  @Mock private VoteResponseRepository voteResponseRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private GroupRepository groupRepository;
+  @Mock private VoteResultRedisService voteResultRedisService;
+  @Mock private GroupMemberRepository groupMemberRepository;
+  @Mock private VoteResultService voteResultService;
+  @Mock private GroupService groupService;
+  @Mock private VoteModerationService voteModerationService;
+
+  @Mock private User user;
+  @Mock private Group group;
+
+  @BeforeEach
+  void setup() {
+    when(user.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(groupRepository.findById(1L)).thenReturn(Optional.of(group));
+  }
+
+  @Nested
+  class 성공_케이스 {
+    /** Vote 저장 및 Redis 캐시 설정 후, voteId 정상 반환 확인 */
+    @Test
+    @DisplayName("투표 등록 성공")
+    public void createVote_success() {
+      // given: 요청 객체 생성
+      VoteCreateRequest request =
+          new VoteCreateRequest(1L, "본문", "", LocalDateTime.now().plusDays(1), false);
+
+      // and: 그룹 공개 설정
+      when(group.isPublicGroup()).thenReturn(true);
+
+      // and: voteRepository.save()가 받은 vote 객체에 id를 수동으로 심어서 리턴
+      when(voteRepository.save(any(Vote.class)))
+          .thenAnswer(
+              invocation -> {
+                Vote savedVote = invocation.getArgument(0);
+                Field idField = Vote.class.getDeclaredField("id");
+                idField.setAccessible(true);
+                idField.set(savedVote, 100L);
+                return savedVote;
+              });
+
+      // when: 테스트 대상 메서드 호출
+      Long result = voteService.createVote(1L, request);
+
+      // then: 결과 및 동작 검증
+      assertThat(result).isEqualTo(100L); // voteId 정상 반환
+      verify(voteRepository).save(any(Vote.class)); // Vote 저장 호출 확인
+      verify(voteResultRedisService)
+          .setCountsWithTTL(eq(100L), anyMap(), any()); // Redis 캐시 설정 호출 확인
+    }
+  }
+
+  @Nested
+  class 실패_케이스 {
+
+    /**
+     * 유효하지 않은 요청으로 투표 생성 시 예외가 발생하는지 검증
+     *
+     * @param request 잘못된 요청 값
+     * @param expectedError 기대되는 에러 코드
+     */
+    @ParameterizedTest
+    @MethodSource("invalidVoteRequests")
+    @DisplayName("잘못된 요청 값")
+    public void createVote_fail_InvalidInput(
+        VoteCreateRequest request, VoteErrorCode expectedError) {
+      // given
+      when(group.isPublicGroup()).thenReturn(true);
+
+      // when & then: 예외 발생 검증
+      assertThatThrownBy(() -> voteService.createVote(1L, request))
+          .isInstanceOf(VoteException.class) // Vote 예외 타입인지 확인
+          .hasMessageContaining(expectedError.name()); // 예외 메시지에 에러 코드 포함 확인
+    }
+
+    /** 그룹에 소속되지 않은 사용자가 투표 생성 시 403 예외 발생 */
+    @Test
+    @DisplayName("그룹 미소속 사용자")
+    public void createVote_fail_NotGroupMember() {
+      // given
+      VoteCreateRequest request =
+          new VoteCreateRequest(1L, "본문", "", LocalDateTime.now().plusDays(1), false);
+
+      // 그룹이 공개 그룹이 아니고, 유저는 멤버가 아님
+      when(group.isPublicGroup()).thenReturn(false);
+      when(groupMemberRepository.findByGroupAndUser(group, user)).thenReturn(Optional.empty());
+
+      // when & then: 예외 발생 검증
+      assertThatThrownBy(() -> voteService.createVote(1L, request))
+          .isInstanceOf(VoteException.class)
+          .hasMessageContaining(VoteErrorCode.NOT_GROUP_MEMBER.name());
+    }
+
+    /** 존재하지 않는 그룹 ID로 투표 생성 시 404 예외 발생 */
+    @Test
+    @DisplayName("존재하지 않는 그룹")
+    public void createVote_fail_GroupNotFound() {
+      // given: 요청은 정상이나, 그룹 ID에 해당하는 그룹이 없음
+      VoteCreateRequest request =
+          new VoteCreateRequest(1L, "본문", "", LocalDateTime.now().plusDays(1), false);
+
+      // 그룹 조회 실패 (Optional.empty())
+      when(groupRepository.findById(1L)).thenReturn(Optional.empty());
+
+      // when & then: GROUP_NOT_FOUND 예외 검증
+      assertThatThrownBy(() -> voteService.createVote(1L, request))
+          .isInstanceOf(VoteException.class)
+          .hasMessageContaining(VoteErrorCode.GROUP_NOT_FOUND.name());
+    }
+
+    static Stream<Arguments> invalidVoteRequests() {
+      return Stream.of(
+          Arguments.of( // 본문 길이 초과
+              new VoteCreateRequest(
+                  1L, "A".repeat(101), "", LocalDateTime.now().plusDays(1), false),
+              VoteErrorCode.INVALID_CONTENT),
+          Arguments.of( // 이미지 URL 잘못됨
+              new VoteCreateRequest(
+                  1L, "정상 본문", "not-a-url", LocalDateTime.now().plusDays(1), false),
+              VoteErrorCode.INVALID_URL),
+          Arguments.of( // 종료 시각 과거
+              new VoteCreateRequest(1L, "정상 본문", "", LocalDateTime.now().minusDays(1), false),
+              VoteErrorCode.INVALID_TIME));
+    }
+  }
+}

--- a/src/test/java/com/moa/moa_server/unit/vote/service/VoteDetailTest.java
+++ b/src/test/java/com/moa/moa_server/unit/vote/service/VoteDetailTest.java
@@ -71,13 +71,13 @@ public class VoteDetailTest {
     @DisplayName("참여자(유효 응답)가 조회")
     void getVoteDetail_success_participant() {
       // given: 투표에 응답한 참여자가 조회 (유효 응답: 1 또는 2)
-      User user2 = mock(User.class);
-      when(user2.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
-      when(userRepository.findById(2L)).thenReturn(Optional.of(user2));
+      User participant = mock(User.class);
+      when(participant.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+      when(userRepository.findById(2L)).thenReturn(Optional.of(participant));
       when(vote.getUser()).thenReturn(mock(User.class)); // 작성자와 다름
       VoteResponse voteResponse = mock(VoteResponse.class);
       when(voteResponse.getOptionNumber()).thenReturn(1);
-      when(voteResponseRepository.findByVoteAndUser(vote, user2))
+      when(voteResponseRepository.findByVoteAndUser(vote, participant))
           .thenReturn(Optional.of(voteResponse));
 
       // when

--- a/src/test/java/com/moa/moa_server/unit/vote/service/VoteDetailTest.java
+++ b/src/test/java/com/moa/moa_server/unit/vote/service/VoteDetailTest.java
@@ -1,0 +1,168 @@
+package com.moa.moa_server.unit.vote.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.vote.dto.response.VoteDetailResponse;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.entity.VoteResponse;
+import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
+import com.moa.moa_server.domain.vote.handler.VoteException;
+import com.moa.moa_server.domain.vote.repository.VoteRepository;
+import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
+import com.moa.moa_server.domain.vote.service.VoteService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VoteService#getVoteDetail")
+public class VoteDetailTest {
+
+  @InjectMocks private VoteService voteService;
+
+  @Mock private VoteRepository voteRepository;
+  @Mock private VoteResponseRepository voteResponseRepository;
+  @Mock private UserRepository userRepository;
+
+  @Mock private User user;
+  @Mock private Vote vote;
+  @Mock private Group group;
+
+  @Nested
+  class 성공_케이스 {
+
+    @BeforeEach
+    void setup() {
+      when(voteRepository.findById(10L)).thenReturn(Optional.of(vote));
+      when(vote.getVoteStatus()).thenReturn(Vote.VoteStatus.OPEN);
+      when(vote.getGroup()).thenReturn(group);
+      when(vote.getId()).thenReturn(10L);
+    }
+
+    @Test
+    @DisplayName("등록자가 조회")
+    void getVoteDetail_success_author() {
+      // given
+      when(vote.getUser()).thenReturn(user);
+      when(user.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+      when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+      // when
+      VoteDetailResponse result = voteService.getVoteDetail(1L, 10L);
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.voteId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("참여자(유효 응답)가 조회")
+    void getVoteDetail_success_participant() {
+      // given: 투표에 응답한 참여자가 조회 (유효 응답: 1 또는 2)
+      User user2 = mock(User.class);
+      when(user2.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+      when(userRepository.findById(2L)).thenReturn(Optional.of(user2));
+      when(vote.getUser()).thenReturn(mock(User.class)); // 작성자와 다름
+      VoteResponse voteResponse = mock(VoteResponse.class);
+      when(voteResponse.getOptionNumber()).thenReturn(1);
+      when(voteResponseRepository.findByVoteAndUser(vote, user2))
+          .thenReturn(Optional.of(voteResponse));
+
+      // when
+      VoteDetailResponse result = voteService.getVoteDetail(2L, 10L);
+
+      // then
+      assertThat(result).isNotNull();
+    }
+  }
+
+  @Nested
+  class 실패_케이스 {
+    // 투표 상태: PENDING/REJECTED 상태는 조회 불가. 투표가 정상 등록된 상태일 때만 조회 가능함 -> 403
+    // 조회 권한: 참여자이지만 기권으로 투표한 경우, 투표하지 않은 경우 -> 403
+    // 투표 없음 -> 404
+
+    @Test
+    @DisplayName("투표 상태 비정상(PENDING, REJECTED)")
+    void getVoteDetail_fail_notOpenOrClosed() {
+      // given
+      when(user.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+      when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+      when(vote.getVoteStatus()).thenReturn(Vote.VoteStatus.PENDING);
+      when(voteRepository.findById(10L)).thenReturn(Optional.of(vote));
+
+      // when & then
+      assertThatThrownBy(() -> voteService.getVoteDetail(1L, 10L))
+          .isInstanceOf(VoteException.class)
+          .hasMessageContaining(VoteErrorCode.FORBIDDEN.name());
+    }
+
+    @Test
+    @DisplayName("참여자/등록자 아님")
+    void getVoteDetail_fail_notAuthorNorParticipant() {
+      // given
+      User stranger = mock(User.class);
+      when(stranger.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+      when(userRepository.findById(3L)).thenReturn(Optional.of(stranger));
+      when(voteRepository.findById(10L)).thenReturn(Optional.of(vote));
+      when(vote.getVoteStatus()).thenReturn(Vote.VoteStatus.OPEN);
+      when(vote.getUser()).thenReturn(mock(User.class)); // 작성자와 다름
+      when(voteResponseRepository.findByVoteAndUser(vote, stranger))
+          .thenReturn(Optional.empty()); // 참여 응답 없음
+
+      // when & then
+      assertThatThrownBy(() -> voteService.getVoteDetail(3L, 10L))
+          .isInstanceOf(VoteException.class)
+          .hasMessageContaining(VoteErrorCode.FORBIDDEN.name());
+    }
+
+    @Test
+    @DisplayName("참여했지만 기권(0) 응답")
+    void getVoteDetail_fail_participatedButAbstained() {
+      // given
+      User stranger = mock(User.class);
+      when(stranger.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+      when(userRepository.findById(4L)).thenReturn(Optional.of(stranger));
+      when(voteRepository.findById(10L)).thenReturn(Optional.of(vote));
+      when(vote.getVoteStatus()).thenReturn(Vote.VoteStatus.OPEN);
+      when(vote.getUser()).thenReturn(mock(User.class)); // 작성자와 다름
+
+      // and: 기권(0)으로 응답
+      VoteResponse abstained = mock(VoteResponse.class);
+      when(abstained.getOptionNumber()).thenReturn(0);
+      when(voteResponseRepository.findByVoteAndUser(vote, stranger))
+          .thenReturn(Optional.of(abstained));
+
+      // when & then
+      assertThatThrownBy(() -> voteService.getVoteDetail(4L, 10L))
+          .isInstanceOf(VoteException.class)
+          .hasMessageContaining(VoteErrorCode.FORBIDDEN.name());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 투표 ID")
+    void getVoteDetail_fail_voteNotFound() {
+      // given
+      when(user.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+      when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+      when(voteRepository.findById(999L)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> voteService.getVoteDetail(1L, 999L))
+          .isInstanceOf(VoteException.class)
+          .hasMessageContaining(VoteErrorCode.VOTE_NOT_FOUND.name());
+    }
+  }
+}

--- a/src/test/java/com/moa/moa_server/unit/vote/service/VoteResultTest.java
+++ b/src/test/java/com/moa/moa_server/unit/vote/service/VoteResultTest.java
@@ -1,0 +1,101 @@
+package com.moa.moa_server.unit.vote.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.entity.VoteResponse;
+import com.moa.moa_server.domain.vote.repository.VoteRepository;
+import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
+import com.moa.moa_server.domain.vote.service.VoteService;
+import com.moa.moa_server.domain.vote.service.vote_result.VoteResultService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VoteService#getVoteResult")
+public class VoteResultTest {
+
+  @InjectMocks private VoteService voteService;
+
+  @Mock private VoteRepository voteRepository;
+  @Mock private VoteResponseRepository voteResponseRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private VoteResultService voteResultService;
+
+  @Mock private User user;
+  @Mock private Vote vote;
+
+  @Nested
+  class 성공_케이스 {
+
+    @BeforeEach
+    void setup() {
+      when(voteRepository.findById(10L)).thenReturn(Optional.of(vote));
+      when(vote.getVoteStatus()).thenReturn(Vote.VoteStatus.OPEN);
+    }
+
+    @Test
+    @DisplayName("등록자가 조회")
+    void getVoteResult_success_author() {
+      // given
+      when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+      when(user.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+      when(vote.getUser()).thenReturn(user);
+      when(voteResponseRepository.findByVoteAndUser(vote, user))
+          .thenReturn(Optional.empty()); // 응답 X
+      when(voteResponseRepository.findAllByVote(vote)).thenReturn(List.of());
+      when(voteResultService.getResults(vote)).thenReturn(List.of());
+
+      // when
+      var result = voteService.getVoteResult(1L, 10L);
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.voteId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("참여자(유효 응답)가 조회")
+    void getVoteResult_success_participant() {
+      // given
+      User participant = mock(User.class);
+      when(participant.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+      when(userRepository.findById(2L)).thenReturn(Optional.of(participant));
+      when(vote.getUser()).thenReturn(mock(User.class)); // 등록자 아님
+      VoteResponse voteResponse = mock(VoteResponse.class);
+      when(voteResponse.getOptionNumber()).thenReturn(1);
+      when(voteResponseRepository.findByVoteAndUser(vote, participant))
+          .thenReturn(Optional.of(voteResponse));
+      when(voteResponseRepository.findAllByVote(vote)).thenReturn(List.of(voteResponse));
+      when(voteResultService.getResults(vote)).thenReturn(List.of());
+
+      // when
+      var result = voteService.getVoteResult(2L, 10L);
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.userResponse()).isEqualTo(1);
+    }
+  }
+
+  @Nested
+  class 실패_케이스 {
+    // 투표 상태: PENDING/REJECTED 상태는 조회 불가. 투표가 정상 등록된 상태일 때만 조회 가능함 -> 403
+    // 조회 권한: 참여자이지만 기권으로 투표한 경우, 투표하지 않은 경우 -> 403
+    // 투표 없음 -> 404
+
+    // getVoteDetail과 동일한 예외 처리 케이스로, 중복 테스트 생략
+  }
+}

--- a/src/test/java/com/moa/moa_server/unit/vote/service/VoteSubmitTest.java
+++ b/src/test/java/com/moa/moa_server/unit/vote/service/VoteSubmitTest.java
@@ -160,7 +160,7 @@ public class VoteSubmitTest {
       // when & then
       assertThatThrownBy(() -> voteService.submitVote(1L, 999L, request))
           .isInstanceOf(VoteException.class)
-          .hasMessageContaining("VOTE_NOT_FOUND");
+          .hasMessageContaining(VoteErrorCode.VOTE_NOT_FOUND.name());
     }
   }
 }

--- a/src/test/java/com/moa/moa_server/unit/vote/service/VoteSubmitTest.java
+++ b/src/test/java/com/moa/moa_server/unit/vote/service/VoteSubmitTest.java
@@ -1,0 +1,166 @@
+package com.moa.moa_server.unit.vote.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.entity.GroupMember;
+import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.vote.dto.request.VoteSubmitRequest;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.entity.VoteResponse;
+import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
+import com.moa.moa_server.domain.vote.handler.VoteException;
+import com.moa.moa_server.domain.vote.repository.VoteRepository;
+import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
+import com.moa.moa_server.domain.vote.service.VoteService;
+import com.moa.moa_server.domain.vote.service.vote_result.VoteResultRedisService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VoteService#submitVote")
+public class VoteSubmitTest {
+
+  @InjectMocks private VoteService voteService;
+
+  @Mock private VoteRepository voteRepository;
+  @Mock private VoteResponseRepository voteResponseRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private VoteResultRedisService voteResultRedisService;
+  @Mock private GroupMemberRepository groupMemberRepository;
+
+  @Mock private User user;
+  @Mock private Vote vote;
+  @Mock private Group group;
+
+  @BeforeEach
+  void setup() {
+    when(user.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(voteRepository.findById(10L)).thenReturn(Optional.of(vote));
+    when(vote.isOpen()).thenReturn(true);
+    when(vote.getGroup()).thenReturn(group);
+    when(group.isPublicGroup()).thenReturn(true);
+  }
+
+  @Nested
+  class 성공_케이스 {
+    @Test
+    @DisplayName("정상 투표 제출(공개 그룹)")
+    void submitVote_success_public() {
+      // given
+      VoteSubmitRequest request = new VoteSubmitRequest(1);
+      when(voteResponseRepository.existsByVoteAndUser(vote, user)).thenReturn(false);
+      VoteResponse vr = mock(VoteResponse.class);
+      when(voteResponseRepository.save(any(VoteResponse.class))).thenReturn(vr);
+
+      // when
+      voteService.submitVote(1L, 10L, request);
+
+      // then
+      verify(voteResponseRepository).save(any(VoteResponse.class));
+      verify(voteResultRedisService).incrementOptionCount(10L, 1);
+    }
+
+    @Test
+    @DisplayName("비공개 그룹, 그룹 멤버만 투표 가능")
+    void submitVote_success_private_member() {
+      // given
+      when(group.isPublicGroup()).thenReturn(false);
+      when(groupMemberRepository.findByGroupAndUser(group, user))
+          .thenReturn(Optional.of(mock(GroupMember.class)));
+      VoteSubmitRequest request = new VoteSubmitRequest(2);
+      when(voteResponseRepository.existsByVoteAndUser(vote, user)).thenReturn(false);
+
+      // when
+      voteService.submitVote(1L, 10L, request);
+
+      // then
+      verify(voteResponseRepository).save(any(VoteResponse.class));
+      verify(voteResultRedisService).incrementOptionCount(10L, 2);
+    }
+  }
+
+  @Nested
+  class 실패_케이스 {
+    @Test
+    @DisplayName("이미 투표한 유저")
+    void submitVote_fail_alreadyVoted() {
+      // given
+      VoteSubmitRequest request = new VoteSubmitRequest(1);
+      when(voteResponseRepository.existsByVoteAndUser(vote, user)).thenReturn(true);
+
+      // when & then
+      assertThatThrownBy(() -> voteService.submitVote(1L, 10L, request))
+          .isInstanceOf(VoteException.class)
+          .hasMessageContaining(VoteErrorCode.ALREADY_VOTED.name());
+    }
+
+    @Test
+    @DisplayName("잘못된 응답값")
+    void submitVote_fail_invalidOption() {
+      // given
+      VoteSubmitRequest request = new VoteSubmitRequest(9); // 0,1,2만 유효
+
+      // when & then
+      assertThatThrownBy(() -> voteService.submitVote(1L, 10L, request))
+          .isInstanceOf(VoteException.class)
+          .hasMessageContaining(VoteErrorCode.INVALID_OPTION.name());
+    }
+
+    @Test
+    @DisplayName("비공개 그룹, 미가입자 예외")
+    void submitVote_fail_private_not_member() {
+      // given
+      when(group.isPublicGroup()).thenReturn(false);
+      when(groupMemberRepository.findByGroupAndUser(group, user)).thenReturn(Optional.empty());
+
+      VoteSubmitRequest request = new VoteSubmitRequest(1);
+
+      // when & then
+      assertThatThrownBy(() -> voteService.submitVote(1L, 10L, request))
+          .isInstanceOf(VoteException.class)
+          .hasMessageContaining(VoteErrorCode.NOT_GROUP_MEMBER.name());
+    }
+
+    @Test
+    @DisplayName("투표가 이미 닫힘")
+    void submitVote_fail_voteClosed() {
+      // given
+      when(vote.isOpen()).thenReturn(false);
+      VoteSubmitRequest request = new VoteSubmitRequest(1);
+
+      // when & then
+      assertThatThrownBy(() -> voteService.submitVote(1L, 10L, request))
+          .isInstanceOf(VoteException.class)
+          .hasMessageContaining(VoteErrorCode.VOTE_NOT_OPENED.name());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 투표 ID")
+    void submitVote_fail_voteNotFound() {
+      // given
+      when(voteRepository.findById(999L)).thenReturn(Optional.empty());
+      VoteSubmitRequest request = new VoteSubmitRequest(1);
+
+      // when & then
+      assertThatThrownBy(() -> voteService.submitVote(1L, 999L, request))
+          .isInstanceOf(VoteException.class)
+          .hasMessageContaining("VOTE_NOT_FOUND");
+    }
+  }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop


### PR DESCRIPTION
## 📌 관련 이슈

* Closes #135

## 🔥 작업 개요

* 투표 서비스 주요 API(등록, 참여, 상세, 결과, 목록)에 대한 단위 테스트 코드 작성

## 🛠️ 작업 상세

1. **투표 등록 및 참여 테스트**

   * `VoteService#createVote`, `submitVote` 단위 테스트 작성
   * 성공/실패 케이스(중복 응답, 권한, 유효성 등) 검증

2. **투표 상세 및 결과 조회 테스트**

   * 등록자/참여자(유효 응답) 상세/결과 조회 성공 케이스
   * 권한 없음, 기권, 상태 비정상, 미존재 투표 등 예외 케이스 테스트

3. **진행 중 투표 목록(ActiveVoteList) 조회 테스트**

   * 비로그인(공개/비공개 그룹), 로그인(공개/비공개 그룹, 그룹 멤버십) 케이스별 분기 검증
   * 커서 기반 페이지네이션 정상 작동 여부 체크

## 🧪 테스트

* [x] 투표 등록/응답/상세/목록 조회 단위 테스트 작성 및 통과 확인
* [x] Mock 기반 Repository, Entity 세팅 및 검증

## 💬 기타 논의 사항

* 추후 작업 계획
    * 투표 결과 관련 서비스 별도 진행 예정 (`VoteResultService`, `VoteResultResolver`, `VoteResultRedisService`, `VoteResultDbWriter`)
    * 컨트롤러 테스트, 통합 테스트 진행 예정