### PR TITLE
cicd: main 브랜치 버전 자동 태그

### DIFF
--- a/.github/workflows/cicd-docker.yml
+++ b/.github/workflows/cicd-docker.yml
@@ -7,8 +7,6 @@ on:
       - develop
       - cicd/**
       - release/**
-    tags:
-      - 'v*'
 
 jobs:
   build-and-deploy:
@@ -19,6 +17,8 @@ jobs:
     steps:
       - name: 🐵 Checkout Repository
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: 🐵 Set up JDK 21
         uses: actions/setup-java@v3
@@ -28,6 +28,36 @@ jobs:
 
       - name: 🐵 Grant execute permission to Gradle
         run: chmod +x gradlew
+
+      - name: 🐵 Extract version from build.gradle
+        id: version
+        if: github.ref_name == 'main' 
+        run: |
+          VERSION=$(grep '^version' build.gradle | awk -F"'" '{print $2}')
+          echo "version=$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: 🐵 Create Git Tag (if not exists)
+        if: github.ref_name == 'main' 
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          echo "현재 토큰: ${GH_PAT:0:4}****"
+          git remote set-url origin https://x-access-token:${GH_PAT}@github.com/${{ github.repository }}
+          git config --get remote.origin.url
+
+          git fetch --tags
+          TAG=${{ steps.version.outputs.version }}
+          if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "✅ Tag $TAG already exists"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag $TAG
+            git remote set-url origin https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}
+            git push origin $TAG
+            echo "✅ Created Git tag: $TAG"
+          fi
 
       - name: 🐵 Build JAR (no tests)
         run: |
@@ -49,13 +79,10 @@ jobs:
           IMAGE_NAME=4moa/moa-be-dev
           TAG=${COMMIT_SHA::7}
 
-          # prod 태그인 경우
-          if [[ "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          # main 레포인 경우
+          if [[ "$REF_NAME" == "main" ]] ; then
             IMAGE_NAME=4moa/moa-be
-            TAG=$REF_NAME
-          elif [[ "$REF_NAME" == "main" ]]; then
-            IMAGE_NAME=4moa/moa-be
-            TAG=latest
+            TAG=${{ steps.version.outputs.version }}
           fi
 
           echo "Image Name: $IMAGE_NAME"
@@ -69,11 +96,11 @@ jobs:
           REF_NAME=${{ github.ref_name }}
 
           DOCKERFILE_PATH=Dockerfile
-          if [[ "$REF_NAME" != "main" && ! "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ "$REF_NAME" != "main" ]]; then
             DOCKERFILE_PATH=Dockerfile.dev
           fi
 
-          echo "📄 Using Dockerfile: $DOCKERFILE_PATH"
+          echo "🐵 Using Dockerfile: $DOCKERFILE_PATH"
 
           docker buildx build \
             --platform linux/amd64 \
@@ -92,6 +119,8 @@ jobs:
         env:
           IMAGE_NAME: ${{ steps.tagger.outputs.image_name }}
           IMAGE_TAG: ${{ steps.tagger.outputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+
         run: |
           ssh -i key.pem -o StrictHostKeyChecking=no cicd@${{ secrets.GCP_BE_HOST }} <<EOF
             set -e
@@ -109,7 +138,7 @@ jobs:
             docker rm moa-backend || true
 
             echo "🐵 Writing .env on remote server..."
-            if [[ "$REF_NAME" == "main" || "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            if [[ "$REF_NAME" == "main" ]]; then
               cat <<EENV | sudo tee /home/cicd/moa-backend.env > /dev/null
           SPRING_PROFILES_ACTIVE=${{ secrets.SPRING_PROFILE }}
           SPRING_DATASOURCE_URL=${{ secrets.DB_URL }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN ./gradlew clean build -x test
 FROM eclipse-temurin:21-jdk
 WORKDIR /app
 
-COPY --from=builder /app/build/libs/moa-server-0.0.1-SNAPSHOT.jar app.jar
+COPY --from=builder /app/build/libs/moa-server-*.jar app.jar
 
 CMD ["java", "-jar", "app.jar"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,6 +13,6 @@ RUN ./gradlew clean build -x test
 FROM eclipse-temurin:21-jdk
 WORKDIR /app
 
-COPY --from=builder /app/build/libs/moa-server-0.0.1-SNAPSHOT.jar app.jar
+COPY --from=builder /app/build/libs/moa-server-*.jar app.jar
 
 CMD ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## 📌 관련 이슈

* 클라우드 # 116

## 🔥 작업 개요

* 기존 CI/CD 버전 트리거 삭제 및 자동 버저닝 기능 추가

## 🛠️ 작업 상세

1. Dockerfile 수정

   * 버전에 맞게 생성되는 .jar 파일을 사용하기 위해 기존 버전 하드코딩 대신 와일드카드(*) 사용하도록 변경

2. CI/CD 트리거 변경

   * v로 시작하는 버전 태그 트리거 삭제, main 브랜치 트리거로 변경
   

## 🧪 테스트

* [x] main 트리거 정상 동작 확인 (Docker image tag: vX.Y.Z)
* [x] !main 트리거 정상 동작 확인 (Docker image tag: 커밋ID)
