### PR TITLE
feat: S3 Presigned URL 기반 이미지 업로드 및 이동/정리 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,12 @@ repositories {
 	mavenCentral()
 }
 
+dependencyManagement {
+  imports {
+    mavenBom "software.amazon.awssdk:bom:2.20.0"
+  }
+}
+
 dependencies {
 	// Spring
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -57,6 +63,9 @@ dependencies {
 
   // Redis
   implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+  // AWS
+  implementation 'software.amazon.awssdk:s3'
 
 	// Swagger
 	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8"

--- a/src/main/java/com/moa/moa_server/config/aws/AwsS3Config.java
+++ b/src/main/java/com/moa/moa_server/config/aws/AwsS3Config.java
@@ -1,0 +1,25 @@
+package com.moa.moa_server.config.aws;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class AwsS3Config {
+
+  @Bean
+  public S3Presigner s3Presigner(
+      @Value("${cloud.aws.credentials.access-key}") String accessKey,
+      @Value("${cloud.aws.credentials.secret-key}") String secretKey,
+      @Value("${cloud.aws.region.static}") String region) {
+    return S3Presigner.builder()
+        .region(Region.of(region))
+        .credentialsProvider(
+            StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+        .build();
+  }
+}

--- a/src/main/java/com/moa/moa_server/config/aws/AwsS3Config.java
+++ b/src/main/java/com/moa/moa_server/config/aws/AwsS3Config.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -17,6 +18,18 @@ public class AwsS3Config {
       @Value("${cloud.aws.credentials.secret-key}") String secretKey,
       @Value("${cloud.aws.region.static}") String region) {
     return S3Presigner.builder()
+        .region(Region.of(region))
+        .credentialsProvider(
+            StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+        .build();
+  }
+
+  @Bean
+  public S3Client s3Client(
+      @Value("${cloud.aws.credentials.access-key}") String accessKey,
+      @Value("${cloud.aws.credentials.secret-key}") String secretKey,
+      @Value("${cloud.aws.region.static}") String region) {
+    return S3Client.builder()
         .region(Region.of(region))
         .credentialsProvider(
             StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))

--- a/src/main/java/com/moa/moa_server/domain/group/util/GroupValidator.java
+++ b/src/main/java/com/moa/moa_server/domain/group/util/GroupValidator.java
@@ -8,8 +8,7 @@ public class GroupValidator {
 
   private static final Pattern INVITE_CODE_PATTERN = Pattern.compile("^[A-Z0-9]{6,8}$");
   private static final Pattern NAME_PATTERN =
-      Pattern.compile("^(?![\\d\\s])[가-힣a-zA-Z0-9 ]{2,12}$");
-  private static final String UPLOAD_URL_PREFIX = "https://upload-domain/group";
+      Pattern.compile("^(?![\\d\\s])[가-힣ㄱ-ㅎa-zA-Z0-9 ]{2,12}$");
 
   private GroupValidator() {
     throw new AssertionError("유틸 클래스는 인스턴스화할 수 없습니다.");
@@ -32,12 +31,6 @@ public class GroupValidator {
         || description.isBlank()
         || description.length() < 2
         || description.length() > 50) {
-      throw new GroupException(GroupErrorCode.INVALID_INPUT);
-    }
-  }
-
-  public static void validateImageUrl(String imageUrl) {
-    if (imageUrl != null && !imageUrl.isBlank() && !imageUrl.startsWith(UPLOAD_URL_PREFIX)) {
       throw new GroupException(GroupErrorCode.INVALID_INPUT);
     }
   }

--- a/src/main/java/com/moa/moa_server/domain/image/controller/ImageController.java
+++ b/src/main/java/com/moa/moa_server/domain/image/controller/ImageController.java
@@ -1,0 +1,34 @@
+package com.moa.moa_server.domain.image.controller;
+
+import com.moa.moa_server.domain.global.dto.ApiResponse;
+import com.moa.moa_server.domain.image.dto.PresignedUrlRequest;
+import com.moa.moa_server.domain.image.dto.PresignedUrlResponse;
+import com.moa.moa_server.domain.image.service.ImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Image", description = "이미지 도메인 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/image")
+public class ImageController {
+
+  private final ImageService imageService;
+
+  @Operation(
+      summary = "Presigend URL 발급",
+      description = "이미지 업로드를 위한 presigned url과 file url을 발급합니다.")
+  @PostMapping("/presigned-url")
+  public ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
+      @AuthenticationPrincipal Long userId, @RequestBody PresignedUrlRequest request) {
+    PresignedUrlResponse response = imageService.createPresignedUrl(userId, request.fileName());
+    return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/image/dto/PresignedUrlRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/image/dto/PresignedUrlRequest.java
@@ -1,0 +1,7 @@
+package com.moa.moa_server.domain.image.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이미지 업로드용 URL 요청 DTO")
+public record PresignedUrlRequest(
+    @Schema(description = "파일명", example = "test.png") String fileName) {}

--- a/src/main/java/com/moa/moa_server/domain/image/dto/PresignedUrlResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/image/dto/PresignedUrlResponse.java
@@ -1,0 +1,12 @@
+package com.moa.moa_server.domain.image.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이미지 업로드용 URL 응답 DTO")
+public record PresignedUrlResponse(
+    @Schema(
+            description = "S3 Presigned URL (PUT 요청용)",
+            example = "https://.../temp/uuid.jpg?X-Amz-...")
+        String uploadUrl,
+    @Schema(description = "이미지 업로드 후 접근할 수 있는 정적 URL", example = "https://.../temp/uuid.jpg")
+        String fileUrl) {}

--- a/src/main/java/com/moa/moa_server/domain/image/handler/ImageErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/image/handler/ImageErrorCode.java
@@ -5,7 +5,9 @@ import org.springframework.http.HttpStatus;
 
 public enum ImageErrorCode implements BaseErrorCode {
   INVALID_FILE(HttpStatus.BAD_REQUEST),
-  INVALID_URL(HttpStatus.BAD_REQUEST);
+  INVALID_URL(HttpStatus.BAD_REQUEST),
+  FILE_NOT_FOUND(HttpStatus.NOT_FOUND),
+  AWS_S3_ERROR(HttpStatus.INTERNAL_SERVER_ERROR);
 
   private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/image/handler/ImageErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/image/handler/ImageErrorCode.java
@@ -1,0 +1,18 @@
+package com.moa.moa_server.domain.image.handler;
+
+import com.moa.moa_server.domain.global.exception.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum ImageErrorCode implements BaseErrorCode {
+  INVALID_FILE(HttpStatus.BAD_REQUEST);
+
+  private final HttpStatus status;
+
+  ImageErrorCode(HttpStatus status) {
+    this.status = status;
+  }
+
+  public HttpStatus getStatus() {
+    return status;
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/image/handler/ImageErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/image/handler/ImageErrorCode.java
@@ -4,7 +4,8 @@ import com.moa.moa_server.domain.global.exception.BaseErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum ImageErrorCode implements BaseErrorCode {
-  INVALID_FILE(HttpStatus.BAD_REQUEST);
+  INVALID_FILE(HttpStatus.BAD_REQUEST),
+  INVALID_URL(HttpStatus.BAD_REQUEST);
 
   private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/image/handler/ImageException.java
+++ b/src/main/java/com/moa/moa_server/domain/image/handler/ImageException.java
@@ -1,0 +1,10 @@
+package com.moa.moa_server.domain.image.handler;
+
+import com.moa.moa_server.domain.global.exception.BaseErrorCode;
+import com.moa.moa_server.domain.global.exception.BaseException;
+
+public class ImageException extends BaseException {
+  public ImageException(BaseErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
+++ b/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
@@ -1,0 +1,77 @@
+package com.moa.moa_server.domain.image.service;
+
+import com.moa.moa_server.domain.image.dto.PresignedUrlResponse;
+import com.moa.moa_server.domain.image.handler.ImageErrorCode;
+import com.moa.moa_server.domain.image.handler.ImageException;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.handler.UserErrorCode;
+import com.moa.moa_server.domain.user.handler.UserException;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.user.util.AuthUserValidator;
+import java.net.URL;
+import java.time.Duration;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+  private final UserRepository userRepository;
+
+  private final S3Presigner s3Presigner;
+
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+
+  public PresignedUrlResponse createPresignedUrl(Long userId, String fileName) {
+    // 유저 조회 및 유효성 검사
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    AuthUserValidator.validateActive(user);
+
+    if (!isValidExtension(fileName)) {
+      throw new ImageException(ImageErrorCode.INVALID_FILE);
+    }
+
+    // S3 key 생성
+    String extension = fileName.substring(fileName.lastIndexOf("."));
+    String uuid = UUID.randomUUID().toString();
+    String key = "temp/" + uuid + extension;
+
+    // S3에 업로드될 객체 정보
+    PutObjectRequest objectRequest =
+        PutObjectRequest.builder()
+            .bucket(bucket)
+            .key(key)
+            .contentType("image/" + extension.replace(".", ""))
+            .build();
+
+    // Presigned URL 요청 생성 (유효기간: 3분)
+    PutObjectPresignRequest presignRequest =
+        PutObjectPresignRequest.builder()
+            .putObjectRequest(objectRequest)
+            .signatureDuration(Duration.ofMinutes(3))
+            .build();
+
+    // presinged-url 발급
+    URL presignedUrl = s3Presigner.presignPutObject(presignRequest).url();
+
+    // fileUrl
+    String fileUrl = String.format("https://%s.s3.amazonaws.com/%s", bucket, key);
+
+    return new PresignedUrlResponse(presignedUrl.toString(), fileUrl);
+  }
+
+  private boolean isValidExtension(String fileName) {
+    String ext = fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
+    return ext.equals(".jpg") || ext.equals(".jpeg") || ext.equals(".png");
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
+++ b/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
@@ -93,6 +93,14 @@ public class ImageService {
     s3Client.deleteObject(builder -> builder.bucket(bucket).key(tempKey));
   }
 
+  public void validateImageUrl(String imageUrl) {
+    if (imageUrl == null || imageUrl.isBlank()) return;
+    String expectedPrefix = String.format("https://%s.s3.amazonaws.com", bucket);
+    if (!imageUrl.startsWith(expectedPrefix)) {
+      throw new ImageException(ImageErrorCode.INVALID_URL);
+    }
+  }
+
   /** S3 파일 URL에서 key 값 추출 */
   public static String getKeyFromUrl(String url) {
     int idx = url.indexOf(".amazonaws.com/");

--- a/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
+++ b/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
@@ -12,6 +12,7 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -30,6 +31,7 @@ public class ImageService {
   private final S3Presigner s3Presigner;
   private final S3Client s3Client;
 
+  @Setter
   @Value("${cloud.aws.s3.bucket}")
   private String bucket;
 

--- a/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
+++ b/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
@@ -107,6 +107,16 @@ public class ImageService {
     }
   }
 
+  public void deleteImage(String imageUrl) {
+    if (imageUrl == null || imageUrl.isBlank()) return;
+    String key = getKeyFromUrl(imageUrl);
+    try {
+      s3Client.deleteObject(builder -> builder.bucket(bucket).key(key));
+    } catch (S3Exception e) {
+      throw new ImageException(ImageErrorCode.AWS_S3_ERROR);
+    }
+  }
+
   public void validateImageUrl(String imageUrl) {
     if (imageUrl == null || imageUrl.isBlank()) return;
     String expectedPrefix = String.format("https://%s.s3.amazonaws.com", bucket);

--- a/src/main/java/com/moa/moa_server/domain/vote/util/VoteValidator.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/util/VoteValidator.java
@@ -7,8 +7,6 @@ import java.time.ZoneOffset;
 
 public class VoteValidator {
 
-  private static final String UPLOAD_URL_PREFIX = "https://upload-domain/vote";
-
   public static void validateContent(String content) {
     if (content == null || content.isBlank()) {
       throw new VoteException(VoteErrorCode.INVALID_CONTENT);
@@ -16,12 +14,6 @@ public class VoteValidator {
     int codePointLength = content.codePointCount(0, content.length());
     if (codePointLength < 2 || codePointLength > 100) {
       throw new VoteException(VoteErrorCode.INVALID_CONTENT);
-    }
-  }
-
-  public static void validateImageUrl(String imageUrl) {
-    if (imageUrl != null && !imageUrl.isBlank() && !imageUrl.startsWith(UPLOAD_URL_PREFIX)) {
-      throw new VoteException(VoteErrorCode.INVALID_URL);
     }
   }
 

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -23,6 +23,16 @@ kakao:
   redirect-uri: ${FRONTEND_URL}/auth/callback
   admin-key: ${KAKAO_ADMIN_KEY}
 
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+    s3:
+      bucket: ${S3_BUCKET_NAME}
+
 frontend:
   url: ${FRONTEND_URL}
 

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -31,6 +31,16 @@ mock:
   ai:
     enabled: true
 
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+    s3:
+      bucket: ${S3_BUCKET_NAME}
+
 logging:
   level:
     root: INFO

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -19,6 +19,16 @@ kakao:
   redirect-uri: ${FRONTEND_URL}/auth/callback
   admin-key: ${KAKAO_ADMIN_KEY}
 
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+    s3:
+      bucket: ${S3_BUCKET_NAME}
+
 frontend:
   url: ${FRONTEND_URL}
 

--- a/src/test/java/com/moa/moa_server/unit/image/service/ImageServiceTest.java
+++ b/src/test/java/com/moa/moa_server/unit/image/service/ImageServiceTest.java
@@ -1,0 +1,141 @@
+package com.moa.moa_server.unit.image.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.moa.moa_server.domain.image.dto.PresignedUrlResponse;
+import com.moa.moa_server.domain.image.handler.ImageErrorCode;
+import com.moa.moa_server.domain.image.handler.ImageException;
+import com.moa.moa_server.domain.image.service.ImageService;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import java.net.URL;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ImageService")
+class ImageServiceTest {
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private S3Presigner s3Presigner;
+
+  @Mock private S3Client s3Client;
+
+  @Mock private User user;
+
+  @InjectMocks private ImageService imageService;
+
+  @Captor private ArgumentCaptor<CopyObjectRequest> copyCaptor;
+
+  @Captor private ArgumentCaptor<DeleteObjectRequest> deleteCaptor;
+
+  private final String bucket = "test-bucket";
+
+  @Nested
+  @DisplayName("이미지 Presigned URL 발급")
+  class PresignedUrlTest {
+
+    @BeforeEach
+    void setup() {
+      when(user.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+      when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    }
+
+    @Test
+    void 올바른_파일명으로_presigned_url_발급_성공() throws Exception {
+      // given
+      imageService.setBucket(bucket); // 테스트용 버킷명 세팅
+
+      // PresignedPutObjectRequest 모킹
+      PresignedPutObjectRequest fakeRequest = mock(PresignedPutObjectRequest.class);
+      // presign 요청 시 S3 URL을 반환하도록 설정
+      when(fakeRequest.url())
+          .thenReturn(new URL("https://test-bucket.s3.amazonaws.com/temp/fake.png"));
+      // presigner가 어떤 요청이든 fakeRequest를 반환하도록 설정
+      when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class)))
+          .thenReturn(fakeRequest);
+
+      // when
+      PresignedUrlResponse response = imageService.createPresignedUrl(1L, "test.png");
+
+      // then
+      assertThat(response.uploadUrl()).contains("https://"); // 업로드용 presigned-url 검증
+      assertThat(response.fileUrl()).contains("test-bucket"); // 반환 fileUrl에 버킷명 포함 여부 검증
+    }
+
+    @Test
+    void 잘못된_확장자_예외발생() {
+      // given
+      String fileName = "test.txt";
+
+      // when & then
+      assertThatThrownBy(() -> imageService.createPresignedUrl(1L, fileName))
+          .isInstanceOf(ImageException.class)
+          .hasMessageContaining(ImageErrorCode.INVALID_FILE.name());
+    }
+  }
+
+  @Nested
+  @DisplayName("temp → vote/group 이동")
+  class MoveImageTest {
+    @Test
+    void 정상적으로_temp에서_vote로_이미지_이동() {
+      // given
+      String tempImageUrl = "https://test-bucket.s3.amazonaws.com/temp/uuid.png";
+      String targetDir = "vote";
+
+      // when
+      imageService.moveImageFromTempToVote(tempImageUrl, targetDir);
+
+      // then
+      verify(s3Client, times(1)).copyObject(any(Consumer.class));
+      verify(s3Client, times(1)).deleteObject(any(Consumer.class));
+    }
+
+    @Test
+    void S3에_key_없으면_FILE_NOT_FOUND_예외() {
+      // given
+      String tempImageUrl = "https://test-bucket.s3.amazonaws.com/temp/uuid.png";
+      String targetDir = "vote";
+      doThrow(NoSuchKeyException.builder().build()).when(s3Client).copyObject(any(Consumer.class));
+
+      // then
+      assertThatThrownBy(() -> imageService.moveImageFromTempToVote(tempImageUrl, targetDir))
+          .isInstanceOf(ImageException.class)
+          .hasMessageContaining(ImageErrorCode.FILE_NOT_FOUND.name());
+    }
+
+    @Test
+    void temp가_아닌_key는_아무것도_안함() {
+      // given
+      String tempImageUrl = "https://test-bucket.s3.amazonaws.com/vote/uuid.png";
+      // when
+      imageService.moveImageFromTempToVote(tempImageUrl, "vote");
+
+      // then
+      verify(s3Client, never()).copyObject(any(CopyObjectRequest.class));
+      verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+    }
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #103 

## 🔥 작업 개요
- S3 Presigned URL 기반 이미지 업로드, 투표/그룹 이미지 이동 및 삭제 등 이미지 파일 처리 기능 일괄 추가

## 🛠️ 작업 상세

1. **S3 Presigned URL 발급 API 구현**

   * `POST /image/presigned-url` API 추가: 프론트엔드에서 presigned URL 발급받아 클라이언트에서 직접 S3에 이미지 업로드 가능하도록 구현
   * 업로드 경로는 기본적으로 `temp/` 디렉토리 하위에 파일 저장

2. **투표/그룹 생성 시 이미지 이동 처리**

   * 투표/그룹 생성 시, S3의 `temp/` 경로에 업로드된 이미지를 `vote/`, `group/` 디렉토리로 이동하도록 기능 구현
   * 이동 후 실제 경로 기반으로 이미지 URL DB에 저장

3. **이미지 URL 유효성 검사 기능 도입**

   * 이미지 URL이 해당 프로젝트 S3 버킷 경로인지 검증하는 로직 추가 (`ImageService.validateImageUrl`)
   * 이미지 업로드, 투표/그룹 생성 등 모든 경로에서 보안성 강화

4. **S3 파일 삭제 기능 추가**

   * 투표/그룹 등 하드 딜리트 시 S3 이미지 파일도 함께 삭제할 수 있도록 deleteImage 메서드 구현
  
5.  **S3 temp 폴더 자동 만료 정책 적용**

   * S3 버킷 Lifecycle Rule을 활용하여 temp 디렉토리 내 파일은 일정 기간(1일) 경과 시 자동 삭제 처리

## 🧪 테스트

* [x] presigned-url 발급 및 이미지 업로드 정상 동작 확인
* [x] 투표/그룹 생성 시 temp → vote/group 이미지 이동 및 접근 경로 DB 저장 확인
* [x] temp 외 경로/잘못된 URL 업로드 차단 동작 확인
* [x] S3 Key 미존재/삭제 예외 발생 시 404 에러 처리 정상 동작 확인
* [x] 전체 기능 단위/통합 테스트 코드 작성 및 통과

## 💬 기타 논의 사항

* Github Actions 환경 변수에 dev 프로필용 S3 버킷 환경 변수 추가 완료
   prod 환경은 S3 버킷 생성 후, 관련 환경 변수 추후 등록 예정
