### PR TITLE
feat: 투표 검열 사유 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+  testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
   // Prometheus / Micrometer

--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
@@ -6,6 +6,7 @@ import com.moa.moa_server.domain.vote.dto.request.VoteCreateRequest;
 import com.moa.moa_server.domain.vote.dto.request.VoteSubmitRequest;
 import com.moa.moa_server.domain.vote.dto.response.VoteCreateResponse;
 import com.moa.moa_server.domain.vote.dto.response.VoteDetailResponse;
+import com.moa.moa_server.domain.vote.dto.response.VoteModerationReasonResponse;
 import com.moa.moa_server.domain.vote.dto.response.active.ActiveVoteResponse;
 import com.moa.moa_server.domain.vote.dto.response.mine.MyVoteResponse;
 import com.moa.moa_server.domain.vote.dto.response.result.VoteResultResponse;
@@ -102,6 +103,14 @@ public class VoteController {
       @RequestParam(required = false) String cursor,
       @RequestParam(required = false) Integer size) {
     SubmittedVoteResponse response = voteService.getSubmittedVotes(userId, groupId, cursor, size);
+    return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
+  }
+
+  @Operation(summary = "투표 검열 사유 조회", description = "등록 실패한 투표의 검열 사유를 조회합니다.")
+  @GetMapping("/{voteId}/review")
+  public ResponseEntity<ApiResponse<VoteModerationReasonResponse>> getModerationReason(
+      @AuthenticationPrincipal Long userId, @PathVariable Long voteId) {
+    VoteModerationReasonResponse response = voteService.getModerationReason(userId, voteId);
     return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteModerationReasonResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteModerationReasonResponse.java
@@ -1,0 +1,7 @@
+package com.moa.moa_server.domain.vote.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record VoteModerationReasonResponse(
+    @Schema(description = "조회한 투표 ID", example = "123") Long voteId,
+    @Schema(description = "검열 사유", example = "OFFENSIVE_LANGUAGE") String reviewReason) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/handler/VoteErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/handler/VoteErrorCode.java
@@ -16,7 +16,9 @@ public enum VoteErrorCode implements BaseErrorCode {
   VOTE_NOT_OPENED(HttpStatus.FORBIDDEN),
   INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST),
   INVALID_MODERATION_RESULT(HttpStatus.BAD_REQUEST),
-  RESULT_UPDATE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR);
+  RESULT_UPDATE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR),
+  MODERATION_LOG_NOT_FOUND(HttpStatus.NOT_FOUND),
+  ;
 
   private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/vote/repository/VoteModerationLogRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/repository/VoteModerationLogRepository.java
@@ -1,6 +1,9 @@
 package com.moa.moa_server.domain.vote.repository;
 
 import com.moa.moa_server.domain.vote.entity.VoteModerationLog;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface VoteModerationLogRepository extends JpaRepository<VoteModerationLog, Long> {}
+public interface VoteModerationLogRepository extends JpaRepository<VoteModerationLog, Long> {
+  Optional<VoteModerationLog> findFirstByVote_IdOrderByCreatedAtDesc(Long voteId);
+}

--- a/src/main/java/com/moa/moa_server/support/GroupTestFactory.java
+++ b/src/main/java/com/moa/moa_server/support/GroupTestFactory.java
@@ -1,0 +1,13 @@
+package com.moa.moa_server.support;
+
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.user.entity.User;
+
+/** 테스트용 Group 엔티티 객체를 생성하는 팩토리 클래스 */
+public class GroupTestFactory {
+
+  /** 테스트용 더미 Group 엔티티 생성 */
+  public static Group createDummy(User user) {
+    return Group.create(user, "dummyGroup_" + System.nanoTime(), "테스트 그룹 설명", null, "INVITE12");
+  }
+}

--- a/src/main/java/com/moa/moa_server/support/UserTestFactory.java
+++ b/src/main/java/com/moa/moa_server/support/UserTestFactory.java
@@ -1,0 +1,19 @@
+package com.moa.moa_server.support;
+
+import com.moa.moa_server.domain.user.entity.User;
+import java.time.LocalDateTime;
+
+/** 테스트용 User 엔티티 객체를 생성하는 팩토리 클래스 */
+public class UserTestFactory {
+
+  /** 테스트용 더미 User 엔티티 생성 */
+  public static User createDummy() {
+    return User.builder()
+        .nickname("dummyUser")
+        .email("dummy" + System.nanoTime() + "@test.com")
+        .role(User.Role.USER)
+        .userStatus(User.UserStatus.ACTIVE)
+        .lastActiveAt(LocalDateTime.now())
+        .build();
+  }
+}

--- a/src/main/java/com/moa/moa_server/support/VoteTestFactory.java
+++ b/src/main/java/com/moa/moa_server/support/VoteTestFactory.java
@@ -1,0 +1,26 @@
+package com.moa.moa_server.support;
+
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import java.time.LocalDateTime;
+
+/** 테스트용 Vote 엔티티 객체를 생성하는 팩토리 클래스 */
+public class VoteTestFactory {
+
+  /** 테스트용 더미 Vote 엔티티 생성 */
+  public static Vote createDummy(User user, Group group) {
+    return Vote.builder()
+        .user(user)
+        .group(group)
+        .content("테스트 투표")
+        .imageUrl(null)
+        .closedAt(LocalDateTime.now().plusDays(1))
+        .anonymous(false)
+        .voteStatus(Vote.VoteStatus.OPEN)
+        .adminVote(false)
+        .voteType(Vote.VoteType.USER)
+        .lastAnonymousNumber(0)
+        .build();
+  }
+}

--- a/src/test/java/com/moa/moa_server/config/TestJpaAuditingConfig.java
+++ b/src/test/java/com/moa/moa_server/config/TestJpaAuditingConfig.java
@@ -1,0 +1,8 @@
+package com.moa.moa_server.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class TestJpaAuditingConfig {}

--- a/src/test/java/com/moa/moa_server/unit/vote/repository/VoteModerationLogRepositoryTest.java
+++ b/src/test/java/com/moa/moa_server/unit/vote/repository/VoteModerationLogRepositoryTest.java
@@ -1,0 +1,66 @@
+package com.moa.moa_server.unit.vote.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moa.moa_server.config.TestJpaAuditingConfig;
+import com.moa.moa_server.config.querydsl.QuerydslConfig;
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.repository.GroupRepository;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.entity.VoteModerationLog;
+import com.moa.moa_server.domain.vote.repository.VoteModerationLogRepository;
+import com.moa.moa_server.domain.vote.repository.VoteRepository;
+import com.moa.moa_server.support.GroupTestFactory;
+import com.moa.moa_server.support.UserTestFactory;
+import com.moa.moa_server.support.VoteTestFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({TestJpaAuditingConfig.class, QuerydslConfig.class})
+public class VoteModerationLogRepositoryTest {
+
+  @Autowired private VoteModerationLogRepository repository;
+  @Autowired private UserRepository userRepository;
+  @Autowired private GroupRepository groupRepository;
+
+  @Autowired private VoteRepository voteRepository;
+
+  @Test
+  @DisplayName("voteId로 가장 최근 로그 1건을 조회한다")
+  void findFirstByVote_IdOrderByCreatedAtDesc_성공() {
+    // given
+    User user = userRepository.save(UserTestFactory.createDummy());
+    Group group = groupRepository.save(GroupTestFactory.createDummy(user));
+    Vote vote = voteRepository.save(VoteTestFactory.createDummy(user, group));
+    VoteModerationLog log1 =
+        VoteModerationLog.create(
+            vote,
+            VoteModerationLog.ReviewResult.REJECTED,
+            VoteModerationLog.ReviewReason.POLITICAL_CONTENT,
+            "정치적 내용",
+            "ai-v1");
+    VoteModerationLog log2 =
+        VoteModerationLog.create(
+            vote,
+            VoteModerationLog.ReviewResult.APPROVED,
+            VoteModerationLog.ReviewReason.NONE,
+            "",
+            "ai-v2");
+    repository.save(log1);
+    repository.save(log2);
+
+    // when
+    VoteModerationLog found =
+        repository.findFirstByVote_IdOrderByCreatedAtDesc(vote.getId()).orElseThrow();
+
+    // then
+    assertThat(found.getReviewResult()).isEqualTo(VoteModerationLog.ReviewResult.APPROVED);
+    assertThat(found.getReviewReason()).isEqualTo(VoteModerationLog.ReviewReason.NONE);
+  }
+}

--- a/src/test/java/com/moa/moa_server/unit/vote/service/VoteModerationReasonTest.java
+++ b/src/test/java/com/moa/moa_server/unit/vote/service/VoteModerationReasonTest.java
@@ -1,0 +1,103 @@
+package com.moa.moa_server.unit.vote.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.vote.dto.response.VoteModerationReasonResponse;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.entity.VoteModerationLog;
+import com.moa.moa_server.domain.vote.handler.VoteException;
+import com.moa.moa_server.domain.vote.repository.VoteModerationLogRepository;
+import com.moa.moa_server.domain.vote.repository.VoteRepository;
+import com.moa.moa_server.domain.vote.service.VoteService;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VoteService#getModerationReason")
+public class VoteModerationReasonTest {
+
+  @Mock UserRepository userRepository;
+  @Mock VoteRepository voteRepository;
+  @Mock VoteModerationLogRepository voteModerationLogRepository;
+
+  @InjectMocks VoteService voteService;
+
+  @Nested
+  class 성공_테스트 {
+
+    @Test
+    @DisplayName("투표 검열 사유 최신 로그 정상 조회")
+    void getModerationReason_성공() {
+      // given
+      Long userId = 1L;
+      Long voteId = 10L;
+      User user = mock(User.class);
+      Vote vote = mock(Vote.class);
+
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+      when(user.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+      when(user.getId()).thenReturn(userId);
+      when(voteRepository.findById(voteId)).thenReturn(Optional.of(vote));
+      when(vote.getUser()).thenReturn(user); // 등록자 본인 검증
+
+      VoteModerationLog log =
+          VoteModerationLog.builder()
+              .reviewReason(VoteModerationLog.ReviewReason.OFFENSIVE_LANGUAGE)
+              .reviewResult(VoteModerationLog.ReviewResult.REJECTED)
+              .reviewDetail("비속어 포함")
+              .aiVersion("v1.1.0")
+              .vote(vote)
+              .build();
+
+      when(voteModerationLogRepository.findFirstByVote_IdOrderByCreatedAtDesc(voteId))
+          .thenReturn(Optional.of(log));
+
+      // when
+      VoteModerationReasonResponse response = voteService.getModerationReason(userId, voteId);
+
+      // then
+      assertThat(response.voteId()).isEqualTo(voteId);
+      assertThat(response.reviewReason()).isEqualTo("OFFENSIVE_LANGUAGE");
+      // 필요에 따라 상세 필드 등 추가 검증
+    }
+  }
+
+  @Nested
+  class 실패_테스트 {
+
+    @Test
+    @DisplayName("로그가 없으면 예외 발생")
+    void getModerationReason_로그없음_예외() {
+      // given
+      Long userId = 1L;
+      Long voteId = 10L;
+      User user = mock(User.class);
+      Vote vote = mock(Vote.class);
+
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+      when(user.getUserStatus()).thenReturn(User.UserStatus.ACTIVE);
+      when(user.getId()).thenReturn(userId);
+      when(voteRepository.findById(voteId)).thenReturn(Optional.of(vote));
+      when(vote.getUser()).thenReturn(user);
+
+      when(voteModerationLogRepository.findFirstByVote_IdOrderByCreatedAtDesc(voteId))
+          .thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> voteService.getModerationReason(userId, voteId))
+          .isInstanceOf(VoteException.class)
+          .hasMessageContaining("MODERATION_LOG_NOT_FOUND");
+    }
+  }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #162 

## 🔥 작업 개요
- 투표 검열 사유 조회 API 구현

## 🛠️ 작업 상세

- 투표 검열 사유 조회 API 구현 (GET `/api/v1/votes/{voteId}/review`)
   - 투표 등록자 본인만 조회 가능하도록 권한 체크
   - 최신 검열 로그 1건을 반환
   - 검열 로그 없을 시 예외 처리(`MODERATION_LOG_NOT_FOUND`)
- 관련 단위 테스트 추가 (`VoteModerationReasonTest`, `VoteModerationLogRepositoryTest`)
   - 정상 조회, 예외 케이스 검증

## 🧪 테스트

* [x] 본인 투표에 대해 최신 검열 사유 정상 조회
* [x] 검열 로그 없을 시 예외 반환
* [x] 등록자 본인이 아닐 경우 FORBIDDEN 예외

## 💬 기타 논의 사항

* 없음
