### PR TITLE
cicd: 이미지 업로드 기능 관련 시크릿 주입

### DIFF
--- a/.github/workflows/cicd-docker.yml
+++ b/.github/workflows/cicd-docker.yml
@@ -168,6 +168,10 @@ jobs:
           REDIS_URL=${{ secrets.REDIS_URL }}
           REDIS_PORT=${{ secrets.REDIS_PORT }}
           REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}
+          AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }}
+          AWS_REGION=${{ secrets.AWS_REGION }}
+          AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}
+          S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }}
           EENV
             fi
 


### PR DESCRIPTION
## 🔥 작업 개요

* S3를 사용한 이미지 업로드 기능 추가에 따른 시크릿 주입 과정 추가

## 🛠️ 작업 상세

1. 시크릿 주입 과정 추가

   * AWS_ACCESS_KEY, AWS_REGION, AWS_SECRET_KEY, S3_BUCKET_NAME 주입 과정 추가
   

## 🧪 테스트

* [x] cicd/ dev 서버 배포 트리거 정상 동작 확인
