### PR TITLE
cicd: 모니터링을 위한 Dockerfile.dev 수정 및 환경 변수 주입

### DIFF
--- a/.github/workflows/cicd-docker.yml
+++ b/.github/workflows/cicd-docker.yml
@@ -172,6 +172,9 @@ jobs:
           AWS_REGION=${{ secrets.AWS_REGION }}
           AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}
           S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }}
+          ELASTIC_APM_SERVER_URL=${{ secrets.ELASTIC_APM_SERVER_URL }}
+          ELASTIC_APM_SERVICE_NAME=${{ secrets.ELASTIC_APM_SERVICE_NAME }}
+          ELASTIC_APM_ENVIRONMENT=${{ secrets.ELASTIC_APM_ENVIRONMENT }}
           EENV
             fi
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,6 +13,10 @@ RUN ./gradlew clean build -x test
 FROM eclipse-temurin:21-jdk
 WORKDIR /app
 
+COPY --from=docker.elastic.co/observability/apm-agent-java:latest \
+/usr/agent/elastic-apm-agent.jar \
+/elastic-apm-agent.jar
+
 COPY --from=builder /app/build/libs/moa-server-*.jar app.jar
 
-CMD ["java", "-jar", "app.jar"]
+CMD ["java", "-javaagent:/elastic-apm-agent.jar", "-jar", "app.jar"]


### PR DESCRIPTION
## 📌 관련 이슈

- 클라우드 # 124

## 🔥 작업 개요

* Elastic APM 추가를 위한 Dockerfile 수정 및 환경변수 주입

## 🛠️ 작업 상세

1. Dockerfile 수정

* Elastic APM 이미지 복사 과정 추가 및 CMD 실행 시 Agent 실행 과정 추가

2. 환경 변수 주입

* ELASTIC_APM_SERVER_URL, ELASTIC_APM_SERVICE_NAME, ELASTIC_APM_ENVIRONMENT 환경 변수 추가

## 🧪 테스트

* [x] cicd/ dev 서버 배포 트리거 정상 동작 확인
