### PR TITLE
fix: REJECTED/PENDING 투표는 결과 조회 시 빈 리스트 반환하도록 방어 로직 추가

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/vote/service/vote_result/VoteResultResolver.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/vote_result/VoteResultResolver.java
@@ -29,6 +29,12 @@ public class VoteResultResolver {
 
   /** 캐시 또는 DB 상태에 따라 투표 결과를 조회하거나 계산 */
   public List<ResultRaw> getOrComputeResults(Vote vote) {
+    // 0. 반려(REJECTED) 또는 미승인(PENDING) 투표는 결과 없음
+    if (vote.getVoteStatus() == Vote.VoteStatus.REJECTED
+        || vote.getVoteStatus() == Vote.VoteStatus.PENDING) {
+      return List.of();
+    }
+
     // 1. 종료된 투표: DB에서 조회 또는 종료 처리
     log.debug(
         "voteClosedAt={}, now={}, result={}",


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #168 

## 🔥 작업 개요
- REJECTED/PENDING 투표 결과 조회 시 빈 리스트 반환하도록 방어 로직 추가

## 🛠️ 작업 상세

### 작업 배경
- Redis 집계 캐시를 도입하면서, 조회 시점에 종료시각이 지났고 DB에 vote_result 테이블 데이터가 없으면 결과를 생성하고 vote_status를 CLOSED로 변경하도록 구현함
- 여기서 REJECTED/PENDING 투표는 처리되지 않아야하는데, 방어 로직이 없어서 **실제 데이터베이스**에 있는 **REJECTED/PENDING 데이터의 vote_status 값이 모두 CLOSED로 수정되는** 문제 발생

### 작업 내용
- `VoteResultResolver.getOrComputeResults()`에
  - 투표 상태가 REJECTED(반려) 또는 PENDING(미승인)인 경우, 즉시 빈 리스트(List.of()) 반환
  - 해당 투표는 집계/조회/상태 변경 로직을 아예 타지 않도록 처리

## 🧪 테스트

* [x] REJECTED/PENDING 투표 결과 조회 시 CLOSED로 변경되지 않는 것 확인 및 빈 리스트 반환
* [x] APPROVED/CLOSED 등 정상 상태 투표 결과 조회 정상 동작

## 💬 기타 논의 사항

* 머지 후, Dev 환경 데이터베이스에서 기존 REJECTED/PENDING 투표가 CLOSED로 잘못 변경된 데이터 복구 필요 (Local에서 복구 테스트 완료)

아래 쿼리 차례로 실행
1. REJECTED 복구
- moderation_log에 REJECTED 기록이 있는 vote만 vote 테이블에서 vote_status를 REJECTED로 되돌림
```sql
UPDATE vote v
JOIN (
    SELECT DISTINCT vote_id
    FROM vote_moderation_log
    WHERE review_result = 'REJECTED'
) vm
ON v.id = vm.vote_id
SET v.vote_status = 'REJECTED'
WHERE v.vote_status = 'CLOSED' or v.vote_status = 'OPEN';
```
2. PENDING 복구
- moderation_log에 어떠한 기록도 없는 vote(아직 심사 자체가 안 된 투표)의 vote_status를 PENDING으로 복구
```sql
UPDATE vote v
LEFT JOIN vote_moderation_log vm
  ON v.id = vm.vote_id
SET v.vote_status = 'PENDING'
WHERE vm.vote_id IS NULL
  AND v.vote_status = 'CLOSED' or v.vote_status = 'OPEN';
```