### PR TITLE
cicd: AWS 버킷, Redis secret 주입 과정 추가

### DIFF
--- a/.github/workflows/cicd-docker.yml
+++ b/.github/workflows/cicd-docker.yml
@@ -149,6 +149,13 @@ jobs:
           AI_SERVER_URL=${{ secrets.AI_SERVER_URL }}
           KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}
           KAKAO_ADMIN_KEY=${{ secrets.KAKAO_ADMIN_KEY }}
+          REDIS_URL=${{ secrets.REDIS_URL }}
+          REDIS_PORT=${{ secrets.REDIS_PORT }}
+          REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}
+          AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }}
+          AWS_REGION=${{ secrets.AWS_REGION }}
+          AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}
+          S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }}
           OTEL_SERVICE_NAME=${{ secrets.OTEL_SERVICE_NAME }}
           OTEL_EXPORTER_OTLP_ENDPOINT=${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_HEADERS=${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}


### PR DESCRIPTION
## 🔥 작업 개요

* Prod 서버 S3를 사용한 이미지 업로드 기능 추가, Redis 도입에 따른 시크릿 주입 과정 추가

## 🛠️ 작업 상세

1. 시크릿 주입 과정 추가

   * AWS_ACCESS_KEY, AWS_REGION, AWS_SECRET_KEY, S3_BUCKET_NAME, REDIS_URL, REDIS_PORT, REDIS_PASSWORD 주입 과정 추가
   

## 🧪 테스트

* [x] cicd/ dev 서버 배포 트리거 정상 동작 확인
