### PR TITLE
feat: S3 파일명 정책 및 jpg Content-Type 처리 개선

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
+++ b/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
@@ -51,16 +51,13 @@ public class ImageService {
     try {
       // S3 key 생성
       String extension = fileName.substring(fileName.lastIndexOf("."));
+      String contentType = getContentType(extension);
       String uuid = UUID.randomUUID().toString();
       String key = "temp/" + uuid + extension;
 
       // S3에 업로드될 객체 정보
       PutObjectRequest objectRequest =
-          PutObjectRequest.builder()
-              .bucket(bucket)
-              .key(key)
-              .contentType("image/" + extension.replace(".", ""))
-              .build();
+          PutObjectRequest.builder().bucket(bucket).key(key).contentType(contentType).build();
 
       // Presigned URL 요청 생성 (유효기간: 3분)
       PutObjectPresignRequest presignRequest =
@@ -132,6 +129,15 @@ public class ImageService {
     String key = url.substring(idx + ".amazonaws.com/".length());
     if (key.isBlank()) throw new ImageException(ImageErrorCode.INVALID_URL);
     return key;
+  }
+
+  private static String getContentType(String extension) {
+    extension = extension.toLowerCase();
+    return switch (extension) {
+      case ".jpg", ".jpeg" -> "image/jpeg";
+      case ".png" -> "image/png";
+      default -> throw new ImageException(ImageErrorCode.INVALID_FILE);
+    };
   }
 
   private boolean isValidExtension(String fileName) {

--- a/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
+++ b/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
@@ -53,7 +53,7 @@ public class ImageService {
       String extension = fileName.substring(fileName.lastIndexOf("."));
       String contentType = getContentType(extension);
       String uuid = UUID.randomUUID().toString();
-      String key = "temp/" + uuid + extension;
+      String key = "temp/" + uuid + "_" + fileName;
 
       // S3에 업로드될 객체 정보
       PutObjectRequest objectRequest =


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #171 

## 🔥 작업 개요
- S3 파일명 정책 및 jpg Content-Type 처리 개선

## 🛠️ 작업 상세

- S3 업로드 시 파일명에 **uuid + 원본 파일명** 포함되도록 key 생성 방식 개선  
  → ex) `temp/{uuid}_{filename}.ext`
- jpg 확장자 파일의 Content-Type을 `image/jpeg`로 올바르게 지정  

## 🧪 테스트

* [x] png, jpg 등 다양한 확장자 정상 업로드 및 접근 확인
* [x] uuid + 원본 파일명 형식으로 S3 객체 생성 확인

## 💬 기타 논의 사항

* 없음
