### PR TITLE
fix: vote content/group description 컬럼 길이 확장 (#174)

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
+++ b/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
@@ -31,7 +31,7 @@ public class Group extends BaseTimeEntity {
   @Column(name = "name", length = 50, nullable = false, unique = true)
   private String name;
 
-  @Column(name = "description", length = 100, nullable = false)
+  @Column(name = "description", length = 300, nullable = false)
   private String description;
 
   @Column(name = "image_url", length = 500)

--- a/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
@@ -31,7 +31,7 @@ public class Vote extends BaseTimeEntity {
   @JoinColumn(name = "group_id", nullable = false)
   private Group group;
 
-  @Column(length = 100, nullable = false)
+  @Column(length = 400, nullable = false)
   private String content;
 
   @Column(name = "image_url", length = 500)


### PR DESCRIPTION
## 📌 관련 이슈

* #174 

## 🔥 작업 개요

* vote/group 컬럼 길이 확장

## 🛠️ 작업 상세

* vote/group 컬럼 길이 확장
    * vote 테이블 content 컬럼: 100자 → 500자
    * group 테이블 description 컬럼: 50자 → 300자
    * XSS 필터링 등 치환 시 데이터 손실 방지 목적
* prod 스키마 수동 변경 완료

## 💬 기타 논의 사항


