### PR TITLE
feat: vote, group 테이블에 image_name 컬럼 추가 및 파일명 저장 로직 구현

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/group/dto/request/GroupCreateRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/group/dto/request/GroupCreateRequest.java
@@ -7,4 +7,5 @@ public record GroupCreateRequest(
     @Schema(description = "그룹 이름", example = "춘식이 연구회") String name,
     @Schema(description = "그룹 설명", example = "매일 춘식이 사진 공유") String description,
     @Schema(description = "그룹 이미지 URL", example = "https://s3.amazonaws.com/....jpg")
-        String imageUrl) {}
+        String imageUrl,
+    @Schema(description = "그룹 이미지 이름", example = "이미지.jpeg") String imageName) {}

--- a/src/main/java/com/moa/moa_server/domain/group/dto/response/GroupCreateResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/group/dto/response/GroupCreateResponse.java
@@ -10,5 +10,6 @@ public record GroupCreateResponse(
     @Schema(description = "그룹 설명", example = "매일 춘식이 사진 공유") String description,
     @Schema(description = "그룹 이미지 URL", example = "https://s3.amazonaws.com/....jpg")
         String imageUrl,
+    @Schema(description = "그룹 이미지 이름", example = "이미지.jpeg") String imageName,
     @Schema(description = "초대 코드", example = "ABC123") String inviteCode,
     @Schema(description = "생성 시각", example = "2025-04-25T14:00:00") LocalDateTime createdAt) {}

--- a/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
+++ b/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
@@ -37,6 +37,9 @@ public class Group extends BaseTimeEntity {
   @Column(name = "image_url", length = 500)
   private String imageUrl;
 
+  @Column(name = "image_name", length = 300)
+  private String imageName;
+
   @Column(name = "invite_code", length = 20, nullable = false, unique = true)
   private String inviteCode;
 
@@ -44,12 +47,18 @@ public class Group extends BaseTimeEntity {
   private java.time.LocalDateTime deletedAt;
 
   public static Group create(
-      User user, String name, String description, String imageUrl, String inviteCode) {
+      User user,
+      String name,
+      String description,
+      String imageUrl,
+      String imageName,
+      String inviteCode) {
     return Group.builder()
         .user(user)
         .name(name)
         .description(description)
         .imageUrl(imageUrl)
+        .imageName(imageName)
         .inviteCode(inviteCode)
         .build();
   }

--- a/src/main/java/com/moa/moa_server/domain/group/service/GroupService.java
+++ b/src/main/java/com/moa/moa_server/domain/group/service/GroupService.java
@@ -110,6 +110,7 @@ public class GroupService {
     GroupValidator.validateDescription(request.description());
     imageService.validateImageUrl(request.imageUrl());
     String imageUrl = request.imageUrl().isBlank() ? null : request.imageUrl().trim();
+    String imageName = request.imageName().isBlank() ? null : request.imageName().trim();
 
     // 그룹 이름 중복 검사
     if (groupRepository.existsByName(request.name())) {
@@ -123,11 +124,13 @@ public class GroupService {
     if (imageUrl != null) {
       imageService.moveImageFromTempToVote(imageUrl, "group");
       imageUrl = imageUrl.replace("/temp/", "/group/"); // DB에는 vote 경로 저장
+      imageName = XssUtil.sanitize(request.imageName());
     }
 
     // 그룹 생성
     String sanitizedDescription = XssUtil.sanitize(request.description());
-    Group group = Group.create(user, request.name(), sanitizedDescription, imageUrl, inviteCode);
+    Group group =
+        Group.create(user, request.name(), sanitizedDescription, imageUrl, imageName, inviteCode);
     groupRepository.save(group);
 
     // 그룹 멤버 등록
@@ -139,6 +142,7 @@ public class GroupService {
         group.getName(),
         group.getDescription(),
         group.getImageUrl(),
+        group.getImageName(),
         group.getInviteCode(),
         group.getCreatedAt());
   }

--- a/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
+++ b/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
@@ -9,8 +9,6 @@ import com.moa.moa_server.domain.user.handler.UserException;
 import com.moa.moa_server.domain.user.repository.UserRepository;
 import com.moa.moa_server.domain.user.util.AuthUserValidator;
 import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -55,7 +53,7 @@ public class ImageService {
       String extension = fileName.substring(fileName.lastIndexOf("."));
       String contentType = getContentType(extension);
       String uuid = UUID.randomUUID().toString();
-      String key = "temp/" + uuid + "_" + fileName;
+      String key = "temp/" + uuid;
 
       // S3에 업로드될 객체 정보
       PutObjectRequest objectRequest =
@@ -72,9 +70,7 @@ public class ImageService {
       URL presignedUrl = s3Presigner.presignPutObject(presignRequest).url();
 
       // fileUrl
-      String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8);
-      String encodedKey = "temp/" + uuid + "_" + encodedFileName;
-      String fileUrl = String.format("https://%s.s3.amazonaws.com/%s", bucket, encodedKey);
+      String fileUrl = String.format("https://%s.s3.amazonaws.com/%s", bucket, key);
 
       return new PresignedUrlResponse(presignedUrl.toString(), fileUrl);
     } catch (S3Exception e) {
@@ -91,8 +87,8 @@ public class ImageService {
     // targetKey: "vote/uuid.jpg" 또는 "group/uuid.jpg"
     String targetKey = tempKey.replaceFirst("temp/", targetDir + "/");
 
-    // S3 복사
     try {
+      // S3 복사
       s3Client.copyObject(
           builder ->
               builder

--- a/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
+++ b/src/main/java/com/moa/moa_server/domain/image/service/ImageService.java
@@ -9,6 +9,8 @@ import com.moa.moa_server.domain.user.handler.UserException;
 import com.moa.moa_server.domain.user.repository.UserRepository;
 import com.moa.moa_server.domain.user.util.AuthUserValidator;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -70,7 +72,9 @@ public class ImageService {
       URL presignedUrl = s3Presigner.presignPutObject(presignRequest).url();
 
       // fileUrl
-      String fileUrl = String.format("https://%s.s3.amazonaws.com/%s", bucket, key);
+      String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8);
+      String encodedKey = "temp/" + uuid + "_" + encodedFileName;
+      String fileUrl = String.format("https://%s.s3.amazonaws.com/%s", bucket, encodedKey);
 
       return new PresignedUrlResponse(presignedUrl.toString(), fileUrl);
     } catch (S3Exception e) {

--- a/src/main/java/com/moa/moa_server/domain/user/dto/response/GroupDetail.java
+++ b/src/main/java/com/moa/moa_server/domain/user/dto/response/GroupDetail.java
@@ -11,6 +11,7 @@ public record GroupDetail(
     @Schema(description = "그룹 소개", example = "카카오 부트캠프전용 야자타임 커뮤니티 입니다.") String description,
     @Schema(description = "그룹 이미지 URL", example = "https://s3.amazonaws.com/....jpg")
         String imageUrl,
+    @Schema(description = "그룹 이미지 이름", example = "이미지.jpeg") String imageName,
     @Schema(description = "그룹 초대 코드", example = "E78XC1") String inviteCode,
     @Schema(description = "그룹 내 사용자의 역할", example = "MEMBER") String role) {
   public static GroupDetail from(Group group, GroupMember.Role role) {
@@ -19,6 +20,7 @@ public record GroupDetail(
         group.getName(),
         group.getDescription(),
         group.getImageUrl(),
+        group.getImageName(),
         group.getInviteCode(),
         role.name());
   }

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/request/VoteCreateRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/request/VoteCreateRequest.java
@@ -9,5 +9,6 @@ public record VoteCreateRequest(
     @Schema(description = "투표 본문 내용", example = "에어컨 추우신 분?") String content,
     @Schema(description = "첨부 이미지 URL", example = "https://s3.amazonaws.com/....jpg")
         String imageUrl,
+    @Schema(description = "첨부 이미지 이름", example = "이미지.jpeg") String imageName,
     @Schema(description = "투표 종료 일시", example = "2025-04-21T12:00:00") LocalDateTime closedAt,
     @Schema(description = "투표 등록 익명 여부", example = "false") Boolean anonymous) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteDetailResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteDetailResponse.java
@@ -10,8 +10,9 @@ public record VoteDetailResponse(
     @Schema(description = "투표 등록자 닉네임 (익명 투표인 경우, '익명'으로 전달)", example = "nickname")
         String authorNickname,
     @Schema(description = "투표 본문 내용", example = "에어컨 추우신 분?") String content,
-    @Schema(description = "투표 이미지 URL (없으면 null)", example = "https://s3.amazonaws.com/....jpg")
+    @Schema(description = "투표 이미지 URL (없으면 빈문자열)", example = "https://s3.amazonaws.com/....jpg")
         String imageUrl,
+    @Schema(description = "투표 이미지 이름 (없으면 빈문자열)", example = "이미지.jpeg") String imageName,
     @Schema(description = "투표 시작 시각", example = "2025-04-20T12:00:00") LocalDateTime createdAt,
     @Schema(description = "투표 종료 시각", example = "2025-04-21T12:00:00") LocalDateTime closedAt,
     @Schema(description = "관리자 투표 여부 (0: 일반 투표, 1: 그룹 관리자 생성 투표)", example = "0") int adminVote) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
@@ -37,6 +37,9 @@ public class Vote extends BaseTimeEntity {
   @Column(name = "image_url", length = 500)
   private String imageUrl;
 
+  @Column(name = "image_name", length = 300)
+  private String imageName;
+
   @Column(name = "closed_at", nullable = false)
   private LocalDateTime closedAt;
 
@@ -83,6 +86,7 @@ public class Vote extends BaseTimeEntity {
       Group group,
       String content,
       String imageUrl,
+      String imageName,
       LocalDateTime closedAt,
       boolean anonymous,
       VoteStatus status,
@@ -92,6 +96,7 @@ public class Vote extends BaseTimeEntity {
         .group(group)
         .content(content)
         .imageUrl(imageUrl)
+        .imageName(imageName)
         .closedAt(closedAt)
         .anonymous(anonymous)
         .voteStatus(status)

--- a/src/main/java/com/moa/moa_server/support/GroupTestFactory.java
+++ b/src/main/java/com/moa/moa_server/support/GroupTestFactory.java
@@ -8,6 +8,6 @@ public class GroupTestFactory {
 
   /** 테스트용 더미 Group 엔티티 생성 */
   public static Group createDummy(User user) {
-    return Group.create(user, "dummyGroup_" + System.nanoTime(), "테스트 그룹 설명", null, "INVITE12");
+    return Group.create(user, "dummyGroup_" + System.nanoTime(), "테스트 그룹 설명", null, "", "INVITE12");
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #176 

## 🔥 작업 개요
- vote, group 테이블에 image_name 컬럼 추가 및 파일명 저장 로직 구현

## 🛠️ 작업 상세

### 작업 배경
- 필요성
   - 투표 내용 수정 시 사용자에게 기존 이미지 파일명을 보여주기 위해 파일명을 저장하고 있어야 할 필요성이 생김
   - 기존에는 image_url 컬럼만 있었으며, S3 객체명을 UUID로만 저장하고 있어서 파일명을 따로 저장하고 있지 않았음
- **S3 객체명에 파일명을 포함하는 방식 도입 및 롤백**
    - S3 객체명에 `{UUID}_{파일명}` 이렇게 파일명을 추가하여, image_url에 파일명을 저장하고 FE에서는 이를 파싱하여 사용자에게 보여주도록 구현
    - 한글 파일명을 허용함에 따라 FE에서 파일명을 **두 번 디코딩**해야 하는 문제 발생
        - S3에서 객체가 저장될 때 객체명 인코딩 발생(1회), 고아 이미지 문제 해결 전략으로 투표 등록 시 이미지를 `temp/`에서 `vote/`로 이동할 때 객체명 인코딩이 한 번 더 발생(2회)
        - 위와 같이 모아의 이미지 관리 전략과 S3 기본 동작에 따라 필연적으로 **인코딩이 두 번 발생**
    - FE에서 두 번 디코딩해야 한다는 점, 파일 이름을 URL에 포함하면 URL이 길어지는 점 때문에 이 방식이 실용적이지 않다고 판단
    - 결론: **S3 객체명은 UUID으로만 구성하고, 테이블에 image_name 컬럼을 추가하여 이미지 이름을 별도로 저장하는 방식 채택**
- 기대 효과
    - 한글/특수문자 파일명 안전하게 처리
    - S3 객체명을 깔끔하게 유지
    - 프론트엔드에서 사용자에게 원본 파일명을 쉽게 노출

### 작업 내용
- vote, group 테이블에 image_name 컬럼 추가 및 엔티티/DTO/서비스/문서 일괄 수정
- 이미지 등록/조회 API 및 서비스 로직 전체 수정: 파일명 저장/조회 가능하도록
- 기존 S3 key 방식 유지 (`temp/{UUID}`, `vote/{UUID}`, `group/{UUID}`)

## 🧪 테스트

* [x] 한글 및 특수문자 파일명 presigned-url 발급/업로드/이동/조회 정상 동작
    * [x] 투표 도메인: 이미지 presigned-url 요청 → 이미지 업로드 → 이미지 업로드 확인 → 투표 등록 → 이미지 이동 확인 → 투표 내용 조회
    * [x] 그룹 도메인: 이미지 presigned-url 요청 → 이미지 업로드 → 이미지 업로드 확인 → 그룹 생성 

## 💬 기타 논의 사항

* BE 측 포스트맨 테스트 완료했으며, CD 후 개발 서버에서 테스트 한 번 더 수행 예정
* main 병합 전 Prod DB 컬럼 직접 추가 필요