### PR TITLE
hotfix: v1.4.1

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/vote/service/vote_result/VoteResultResolver.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/vote_result/VoteResultResolver.java
@@ -90,7 +90,8 @@ public class VoteResultResolver {
 
   /** countMap(Long) 기반으로 ResultRaw 리스트 생성 */
   private List<ResultRaw> toResultRawListLong(Map<Integer, Long> countMap) {
-    int total = countMap.values().stream().mapToInt(Number::intValue).sum();
+    int total =
+        Stream.of(1, 2).mapToInt(option -> countMap.getOrDefault(option, 0L).intValue()).sum();
     return Stream.of(1, 2)
         .map(
             option -> {
@@ -103,7 +104,7 @@ public class VoteResultResolver {
 
   /** countMap(Integer) 기반으로 ResultRaw 리스트 생성 */
   private List<ResultRaw> toResultRawListInt(Map<Integer, Integer> countMap) {
-    int total = countMap.values().stream().mapToInt(Number::intValue).sum();
+    int total = Stream.of(1, 2).mapToInt(option -> countMap.getOrDefault(option, 0)).sum();
     return Stream.of(1, 2)
         .map(
             option -> {


### PR DESCRIPTION
## 목적
- 투표 결과 집계 시 기권(option 0) 값이 total에 포함되지 않도록 수정하여 비율(ratio) 계산 오류 해결

## 관련 이슈
- Closes #187

## 내용
- 결과 집계 시 total 계산에서 option 1, 2만 합산하도록 로직 수정
 → 기권(option 0)은 total 및 비율(ratio) 계산에서 제외