### PR TITLE
feat: 댓글 작성 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ dependencies {
 	// 기타
 	implementation "org.apache.httpcomponents.client5:httpclient5:5.4.4" // RestTemplate
 	implementation 'com.navercorp.lucy:lucy-xss:1.6.3' // XSS Filtering
+  implementation 'com.fasterxml.jackson.core:jackson-databind' // JSON 직렬화/역직렬화
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/moa/moa_server/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/controller/CommentController.java
@@ -28,6 +28,6 @@ public class CommentController {
       @PathVariable Long voteId,
       @RequestBody @Valid CommentCreateRequest request) {
     CommentCreateResponse response = commentService.createComment(userId, voteId, request);
-    return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("success", response));
+    return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("SUCCESS", response));
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/controller/CommentController.java
@@ -1,0 +1,33 @@
+package com.moa.moa_server.domain.comment.controller;
+
+import com.moa.moa_server.domain.comment.dto.request.CommentCreateRequest;
+import com.moa.moa_server.domain.comment.dto.response.CommentCreateResponse;
+import com.moa.moa_server.domain.comment.service.CommentService;
+import com.moa.moa_server.domain.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Comment", description = "댓글 도메인 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class CommentController {
+
+  private final CommentService commentService;
+
+  @Operation(summary = "댓글 작성", description = "한 투표에 대해 댓글을 작성합니다.")
+  @PostMapping("/votes/{voteId}/comments")
+  public ResponseEntity<ApiResponse<CommentCreateResponse>> createComment(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long voteId,
+      @RequestBody @Valid CommentCreateRequest request) {
+    CommentCreateResponse response = commentService.createComment(userId, voteId, request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("success", response));
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,0 +1,10 @@
+package com.moa.moa_server.domain.comment.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "댓글 작성 요청 DTO")
+public record CommentCreateRequest(
+    @Schema(description = "댓글 내용", example = "에어컨 추워요") @NotBlank String content,
+    @Schema(description = "익명 여부", example = "false") @NotNull Boolean anonymous) {}

--- a/src/main/java/com/moa/moa_server/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/dto/request/CommentCreateRequest.java
@@ -3,8 +3,9 @@ package com.moa.moa_server.domain.comment.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "댓글 작성 요청 DTO")
 public record CommentCreateRequest(
-    @Schema(description = "댓글 내용", example = "에어컨 추워요") @NotBlank String content,
+    @Schema(description = "댓글 내용", example = "에어컨 추워요") @NotBlank @Size(max = 255) String content,
     @Schema(description = "익명 여부", example = "false") @NotNull Boolean anonymous) {}

--- a/src/main/java/com/moa/moa_server/domain/comment/dto/response/CommentCreateResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/dto/response/CommentCreateResponse.java
@@ -1,0 +1,11 @@
+package com.moa.moa_server.domain.comment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "댓글 작성 응답 DTO")
+public record CommentCreateResponse(
+    @Schema(description = "생성된 댓글 ID", example = "42") Long commentId,
+    @Schema(description = "댓글 내용", example = "저도 그렇게 생각해요!") String content,
+    @Schema(description = "댓글 작성자 닉네임", example = "익명1") String authorNickname,
+    @Schema(description = "댓글 작성 시각", example = "2025-04-25T12:00:00") LocalDateTime createdAt) {}

--- a/src/main/java/com/moa/moa_server/domain/comment/entity/Comment.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/entity/Comment.java
@@ -48,4 +48,24 @@ public class Comment extends BaseTimeEntity {
 
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
+
+  public static Comment create(User user, Vote vote, String content, int anonymousNumber) {
+    return Comment.builder()
+        .user(user)
+        .vote(vote)
+        .content(content)
+        .anonymousNumber(anonymousNumber)
+        .reportCount(0)
+        .hiddenByReport(false)
+        .hiddenByAdmin(false)
+        .build();
+  }
+
+  public boolean isDeleted() {
+    return deletedAt != null;
+  }
+
+  public boolean isHidden() {
+    return hiddenByReport || hiddenByAdmin;
+  }
 }

--- a/src/main/java/com/moa/moa_server/domain/comment/entity/Comment.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/entity/Comment.java
@@ -1,0 +1,51 @@
+package com.moa.moa_server.domain.comment.entity;
+
+import com.moa.moa_server.domain.global.entity.BaseTimeEntity;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "comment")
+public class Comment extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "vote_id", nullable = false)
+  private Vote vote;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Column(length = 500, nullable = false)
+  private String content;
+
+  @Column(name = "anonymous_number", nullable = false)
+  @Builder.Default
+  private int anonymousNumber = 0;
+
+  @Column(name = "report_count", nullable = false)
+  @Builder.Default
+  private int reportCount = 0;
+
+  @Column(name = "hidden_by_report", nullable = false)
+  @Builder.Default
+  private boolean hiddenByReport = false;
+
+  @Column(name = "hidden_by_admin", nullable = false)
+  @Builder.Default
+  private boolean hiddenByAdmin = false;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/moa/moa_server/domain/comment/handler/CommentErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/handler/CommentErrorCode.java
@@ -1,0 +1,20 @@
+package com.moa.moa_server.domain.comment.handler;
+
+import com.moa.moa_server.domain.global.exception.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum CommentErrorCode implements BaseErrorCode {
+  INVALID_CONTENT(HttpStatus.BAD_REQUEST),
+  FORBIDDEN(HttpStatus.FORBIDDEN),
+  VOTE_NOT_FOUND(HttpStatus.NOT_FOUND);
+
+  private final HttpStatus status;
+
+  CommentErrorCode(HttpStatus status) {
+    this.status = status;
+  }
+
+  public HttpStatus getStatus() {
+    return status;
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/comment/handler/CommentException.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/handler/CommentException.java
@@ -1,0 +1,10 @@
+package com.moa.moa_server.domain.comment.handler;
+
+import com.moa.moa_server.domain.global.exception.BaseErrorCode;
+import com.moa.moa_server.domain.global.exception.BaseException;
+
+public class CommentException extends BaseException {
+  public CommentException(BaseErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,13 @@
+package com.moa.moa_server.domain.comment.repository;
+
+import com.moa.moa_server.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+  @Query(
+      "SELECT c.anonymousNumber FROM Comment c WHERE c.vote.id = :voteId AND c.user.id = :userId AND c.anonymousNumber > 0 ORDER BY c.createdAt ASC")
+  Integer findFirstAnonymousNumberByVoteIdAndUserId(
+      @Param("voteId") Long voteId, @Param("userId") Long userId);
+}

--- a/src/main/java/com/moa/moa_server/domain/comment/service/CommentService.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/service/CommentService.java
@@ -1,0 +1,95 @@
+package com.moa.moa_server.domain.comment.service;
+
+import com.moa.moa_server.domain.comment.dto.request.CommentCreateRequest;
+import com.moa.moa_server.domain.comment.dto.response.CommentCreateResponse;
+import com.moa.moa_server.domain.comment.entity.Comment;
+import com.moa.moa_server.domain.comment.handler.CommentErrorCode;
+import com.moa.moa_server.domain.comment.handler.CommentException;
+import com.moa.moa_server.domain.comment.repository.CommentRepository;
+import com.moa.moa_server.domain.global.util.XssUtil;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.handler.UserErrorCode;
+import com.moa.moa_server.domain.user.handler.UserException;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.user.util.AuthUserValidator;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.repository.VoteRepository;
+import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+  private final CommentRepository commentRepository;
+  private final UserRepository userRepository;
+  private final VoteRepository voteRepository;
+  private final VoteResponseRepository voteResponseRepository;
+
+  @Transactional
+  public CommentCreateResponse createComment(
+      Long userId, Long voteId, CommentCreateRequest request) {
+    // 유저 조회 및 유효성 검사
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    AuthUserValidator.validateActive(user);
+
+    // 투표 존재 확인
+    Vote vote =
+        voteRepository
+            .findById(voteId)
+            .orElseThrow(() -> new CommentException(CommentErrorCode.VOTE_NOT_FOUND));
+
+    // 댓글 작성 권한 확인 (투표 참여자이거나 투표 등록자)
+    boolean isOwner = vote.getUser().getId().equals(user.getId());
+    boolean isParticipant = voteResponseRepository.existsByVoteIdAndUserId(voteId, userId);
+    if (!(isOwner || isParticipant)) {
+      throw new CommentException(CommentErrorCode.FORBIDDEN);
+    }
+    // TODO: 권한 추가 - top3 투표인 경우 모든 사용자가 댓글 작성 가능
+
+    // 본문 XSS 필터링
+    String sanitizedContent = XssUtil.sanitize(request.content());
+
+    // 익명 번호 할당 (한 투표 내 동일 작성자는 동일 번호)
+    // TODO: race condition 테스트
+    int anonymousNumber = 0;
+    if (request.anonymous()) {
+      anonymousNumber = getOrAssignAnonymousNumber(vote, user);
+    }
+
+    // 댓글 생성
+    Comment comment = Comment.create(user, vote, sanitizedContent, anonymousNumber);
+
+    commentRepository.save(comment);
+
+    // authorNickname (익명1 or 닉네임)
+    String authorNickname =
+        getAuthorNickname(request.anonymous(), anonymousNumber, user.getNickname());
+
+    return new CommentCreateResponse(
+        comment.getId(), comment.getContent(), authorNickname, comment.getCreatedAt());
+  }
+
+  /** 댓글 테이블에서 익명 번호 조회 및 할당 */
+  private int getOrAssignAnonymousNumber(Vote vote, User user) {
+    // 기존에 달았던 익명 댓글이 있다면 같은 번호, 없다면 새 번호
+    Integer existNumber =
+        commentRepository.findFirstAnonymousNumberByVoteIdAndUserId(vote.getId(), user.getId());
+    if (existNumber != null && existNumber > 0) return existNumber;
+
+    // 새 번호 할당
+    int nextNumber = vote.increaseLastAnonymousNumber();
+    voteRepository.save(vote);
+    return nextNumber;
+  }
+
+  /** 댓글 작성자 닉네임 생성 */
+  private String getAuthorNickname(boolean anonymous, int anonymousNumber, String nickname) {
+    return anonymous ? "익명" + anonymousNumber : nickname;
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/comment/service/CommentService.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/service/CommentService.java
@@ -15,6 +15,7 @@ import com.moa.moa_server.domain.user.util.AuthUserValidator;
 import com.moa.moa_server.domain.vote.entity.Vote;
 import com.moa.moa_server.domain.vote.repository.VoteRepository;
 import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,9 +45,11 @@ public class CommentService {
             .findById(voteId)
             .orElseThrow(() -> new CommentException(CommentErrorCode.VOTE_NOT_FOUND));
 
-    // 댓글 작성 권한 확인 (투표 참여자이거나 투표 등록자)
+    // 댓글 작성 권한 확인 (투표 참여자(유효 응답: 1, 2)이거나 투표 등록자)
     boolean isOwner = vote.getUser().getId().equals(user.getId());
-    boolean isParticipant = voteResponseRepository.existsByVoteIdAndUserId(voteId, userId);
+    boolean isParticipant =
+        voteResponseRepository.existsByVoteIdAndUserIdAndOptionNumberIn(
+            voteId, userId, List.of(1, 2));
     if (!(isOwner || isParticipant)) {
       throw new CommentException(CommentErrorCode.FORBIDDEN);
     }

--- a/src/main/java/com/moa/moa_server/domain/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/moa/moa_server/domain/global/handler/GlobalExceptionHandler.java
@@ -5,6 +5,8 @@ import com.moa.moa_server.domain.global.exception.BaseException;
 import com.moa.moa_server.domain.global.exception.GlobalErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -22,5 +24,24 @@ public class GlobalExceptionHandler {
     log.error("Unhandled Exception Occurred", ex);
     return ResponseEntity.status(500)
         .body(new ApiResponse<>(GlobalErrorCode.UNEXPECTED_ERROR.name(), null));
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiResponse<Void>> handleValidationExceptions(
+      MethodArgumentNotValidException ex) {
+    FieldError error = ex.getBindingResult().getFieldError();
+    String code = "INVALID_REQUEST";
+
+    if (error != null && error.getCode() != null) {
+      code =
+          switch (error.getCode()) {
+            case "NotNull" -> "NULL_" + error.getField().toUpperCase();
+            case "NotBlank" -> "BLANK_" + error.getField().toUpperCase();
+            case "Size" -> "TOO_LONG_" + error.getField().toUpperCase();
+            default -> "INVALID_" + error.getField().toUpperCase();
+          };
+    }
+
+    return ResponseEntity.badRequest().body(new ApiResponse<>(code, null));
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
@@ -116,6 +116,12 @@ public class Vote extends BaseTimeEntity {
     this.voteStatus = VoteStatus.CLOSED;
   }
 
+  /** 마지막 익명 번호 증가 */
+  public int increaseLastAnonymousNumber() {
+    this.lastAnonymousNumber++;
+    return this.lastAnonymousNumber;
+  }
+
   // ======= 조회/편의 메서드 =======
   /** 투표가 OPEN 상태인지 확인 */
   public boolean isOpen() {

--- a/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResponseRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResponseRepository.java
@@ -13,4 +13,6 @@ public interface VoteResponseRepository extends JpaRepository<VoteResponse, Long
   Optional<VoteResponse> findByVoteAndUser(Vote vote, User user);
 
   List<VoteResponse> findAllByVote(Vote vote);
+
+  boolean existsByVoteIdAndUserId(Long voteId, Long userId);
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResponseRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResponseRepository.java
@@ -14,5 +14,5 @@ public interface VoteResponseRepository extends JpaRepository<VoteResponse, Long
 
   List<VoteResponse> findAllByVote(Vote vote);
 
-  boolean existsByVoteIdAndUserId(Long voteId, Long userId);
+  boolean existsByVoteIdAndUserIdAndOptionNumberIn(Long voteId, Long userId, List<Integer> options);
 }

--- a/src/test/java/com/moa/moa_server/integration/comment/CommentCreateIntegrationTest.java
+++ b/src/test/java/com/moa/moa_server/integration/comment/CommentCreateIntegrationTest.java
@@ -1,3 +1,280 @@
 package com.moa.moa_server.integration.comment;
 
-public class CommentCreateIntegrationTest {}
+import static com.moa.moa_server.util.TestFixture.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.moa.moa_server.domain.auth.service.JwtTokenService;
+import com.moa.moa_server.domain.comment.dto.request.CommentCreateRequest;
+import com.moa.moa_server.domain.comment.handler.CommentErrorCode;
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.repository.GroupRepository;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.repository.VoteRepository;
+import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
+import com.moa.moa_server.util.TestUtil;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+public class CommentCreateIntegrationTest {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired UserRepository userRepository;
+  @Autowired GroupRepository groupRepository;
+  @Autowired VoteRepository voteRepository;
+  @Autowired VoteResponseRepository voteResponseRepository;
+  @Autowired JwtTokenService jwtTokenService;
+
+  User testUser;
+  Group testGroup;
+  Vote testVote;
+  String accessToken;
+
+  @BeforeEach
+  void setup() {
+    testUser = userRepository.save(user("testuser"));
+    testGroup = groupRepository.save(group(testUser, "공개"));
+    testVote = voteRepository.save(vote(testUser, testGroup, Vote.VoteStatus.OPEN));
+    accessToken = jwtTokenService.issueAccessToken(testUser.getId());
+  }
+
+  @Nested
+  class 성공_케이스 {
+
+    @Test
+    @DisplayName("투표 등록자 댓글 작성 (실명 댓글)")
+    void createComment_success_writer() throws Exception {
+      // given
+      CommentCreateRequest req = new CommentCreateRequest("댓글 내용", false);
+
+      // when & then
+      mockMvc
+          .perform(
+              post("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + accessToken)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(TestUtil.asJsonString(req)))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.message").value("SUCCESS"))
+          .andExpect(jsonPath("$.data.content").value("댓글 내용"))
+          .andExpect(jsonPath("$.data.authorNickname").value(testUser.getNickname()));
+    }
+
+    @Test
+    @DisplayName("투표 참여자 댓글 작성 (실명 댓글)")
+    void createComment_success_participant() throws Exception {
+      // given: 투표 참여자 유저 추가
+      User participant = userRepository.save(user("participant"));
+      String participantToken = jwtTokenService.issueAccessToken(participant.getId());
+
+      voteResponseRepository.save(voteResponse(testVote, participant, 1));
+
+      CommentCreateRequest req = new CommentCreateRequest("참여자 댓글", false);
+
+      // when & then
+      mockMvc
+          .perform(
+              post("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + participantToken)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(TestUtil.asJsonString(req)))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.message").value("SUCCESS"))
+          .andExpect(jsonPath("$.data.content").value("참여자 댓글"))
+          .andExpect(jsonPath("$.data.authorNickname").value(participant.getNickname()));
+    }
+  }
+
+  @Nested
+  class 성공_케이스_익명 {
+
+    @Test
+    @DisplayName("동일 유저가 익명 댓글 작성 시 익명 번호 유지")
+    void createComment_anonymous_same_user_twice() throws Exception {
+      // given
+      CommentCreateRequest req1 = new CommentCreateRequest("첫 번째 익명", true);
+      CommentCreateRequest req2 = new CommentCreateRequest("두 번째 익명", true);
+
+      // when & then: 첫 번째 익명 댓글
+      mockMvc
+          .perform(
+              post("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + accessToken)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(TestUtil.asJsonString(req1)))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.data.authorNickname").value("익명1"));
+
+      // 두 번째 익명 댓글
+      mockMvc
+          .perform(
+              post("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + accessToken)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(TestUtil.asJsonString(req2)))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.data.authorNickname").value("익명1"));
+    }
+
+    @Test
+    @DisplayName("사용자 A, B, A가 익명 댓글 작성 시 익명1, 익명2, 익명1")
+    void createComment_anonymous_A_B_A() throws Exception {
+      // given: 유저 B 추가
+      User userB = userRepository.save(user("userB"));
+      String tokenB = jwtTokenService.issueAccessToken(userB.getId());
+
+      voteResponseRepository.save(voteResponse(testVote, userB, 1));
+
+      CommentCreateRequest reqA1 = new CommentCreateRequest("A 첫 댓글", true);
+      CommentCreateRequest reqB = new CommentCreateRequest("B 댓글", true);
+      CommentCreateRequest reqA2 = new CommentCreateRequest("A 두번째 댓글", true);
+
+      // when & then: A(익명1)
+      mockMvc
+          .perform(
+              post("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + accessToken)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(TestUtil.asJsonString(reqA1)))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.data.authorNickname").value("익명1"));
+
+      // B(익명2)
+      mockMvc
+          .perform(
+              post("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + tokenB)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(TestUtil.asJsonString(reqB)))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.data.authorNickname").value("익명2"));
+
+      // 다시 A(익명1)
+      mockMvc
+          .perform(
+              post("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + accessToken)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(TestUtil.asJsonString(reqA2)))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.data.authorNickname").value("익명1"));
+    }
+
+    @Test
+    @DisplayName("A가 익명 댓글, 실명 댓글 차례로 작성 시 익명1, 실명 닉네임 반환")
+    void createComment_anonymous_and_realname_mixed() throws Exception {
+      // given
+      CommentCreateRequest reqAnonymous = new CommentCreateRequest("익명", true);
+      CommentCreateRequest reqNamed = new CommentCreateRequest("실명", false);
+
+      // 익명 댓글
+      mockMvc
+          .perform(
+              post("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + accessToken)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(TestUtil.asJsonString(reqAnonymous)))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.data.authorNickname").value("익명1"));
+
+      // 실명 댓글
+      mockMvc
+          .perform(
+              post("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + accessToken)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(TestUtil.asJsonString(reqNamed)))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.data.authorNickname").value(testUser.getNickname()));
+    }
+  }
+
+  @Nested
+  class 실패_케이스 {
+
+    @Test
+    @DisplayName("option=0 응답자는 댓글 작성 권한 없음")
+    void createComment_optionZero_forbidden() throws Exception {
+      // given: userB 기권 응답 등록
+      User userB = userRepository.save(user("userB"));
+      String tokenB = jwtTokenService.issueAccessToken(userB.getId());
+
+      voteResponseRepository.save(voteResponse(testVote, userB, 0));
+
+      CommentCreateRequest req = new CommentCreateRequest("기권자 댓글", false);
+
+      // when & then
+      mockMvc
+          .perform(
+              post("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + tokenB)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(TestUtil.asJsonString(req)))
+          .andExpect(status().isForbidden())
+          .andExpect(jsonPath("$.message").value(CommentErrorCode.FORBIDDEN.name()));
+    }
+
+    @Test
+    @DisplayName("투표 미참여자는 댓글 작성 권한 없음")
+    void createComment_notParticipant_forbidden() throws Exception {
+      // given: userC 미참여자
+      User userC = userRepository.save(user("userC"));
+      String tokenC = jwtTokenService.issueAccessToken(userC.getId());
+
+      CommentCreateRequest req = new CommentCreateRequest("미참여자 댓글", false);
+
+      // when & then
+      mockMvc
+          .perform(
+              post("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + tokenC)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(TestUtil.asJsonString(req)))
+          .andExpect(status().isForbidden())
+          .andExpect(jsonPath("$.message").value(CommentErrorCode.FORBIDDEN.name()));
+    }
+
+    @ParameterizedTest(name = "{1}")
+    @MethodSource("invalidContentProvider")
+    @DisplayName("댓글 본문이 유효하지 않으면 400 반환")
+    void createComment_invalidContent(String content, String testName, String expectedMessage)
+        throws Exception {
+      CommentCreateRequest req = new CommentCreateRequest(content, false);
+
+      mockMvc
+          .perform(
+              post("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + accessToken)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(TestUtil.asJsonString(req)))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message").value(expectedMessage));
+    }
+
+    private static Stream<Arguments> invalidContentProvider() {
+      return Stream.of(
+          Arguments.of("", "빈 문자열", "BLANK_CONTENT"),
+          Arguments.of("a".repeat(256), "255자 초과", "TOO_LONG_CONTENT"));
+    }
+  }
+}

--- a/src/test/java/com/moa/moa_server/integration/comment/CommentCreateIntegrationTest.java
+++ b/src/test/java/com/moa/moa_server/integration/comment/CommentCreateIntegrationTest.java
@@ -1,0 +1,3 @@
+package com.moa.moa_server.integration.comment;
+
+public class CommentCreateIntegrationTest {}

--- a/src/test/java/com/moa/moa_server/util/TestFixture.java
+++ b/src/test/java/com/moa/moa_server/util/TestFixture.java
@@ -1,0 +1,37 @@
+package com.moa.moa_server.util;
+
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.entity.VoteResponse;
+import java.time.LocalDateTime;
+
+public class TestFixture {
+
+  public static User user(String nickname) {
+    return User.builder()
+        .nickname(nickname)
+        .role(User.Role.USER)
+        .userStatus(User.UserStatus.ACTIVE)
+        .lastActiveAt(LocalDateTime.now())
+        .build();
+  }
+
+  public static Group group(User user, String name) {
+    return Group.builder()
+        .name(name)
+        .inviteCode("000000")
+        .user(user)
+        .description("테스트 그룹입니다.")
+        .build();
+  }
+
+  public static Vote vote(User user, Group group, Vote.VoteStatus voteStatus) {
+    return Vote.createUserVote(
+        user, group, "본문입니다", "", "", LocalDateTime.now().plusDays(1), false, voteStatus, false);
+  }
+
+  public static VoteResponse voteResponse(Vote vote, User user, int option) {
+    return VoteResponse.builder().vote(vote).user(user).optionNumber(option).build();
+  }
+}

--- a/src/test/java/com/moa/moa_server/util/TestUtil.java
+++ b/src/test/java/com/moa/moa_server/util/TestUtil.java
@@ -1,0 +1,14 @@
+package com.moa.moa_server.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TestUtil {
+
+  public static String asJsonString(final Object obj) {
+    try {
+      return new ObjectMapper().writeValueAsString(obj);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈

* Closes #189

## 🔥 작업 개요

* 댓글 작성 API 구현

## 🛠️ 작업 상세

* 댓글 도메인 패키지 및 기본 구조 생성
   * 댓글 엔티티, 에러 핸들러, 에러코드, 레포지토리 등 
* 댓글 작성 API 구현 (`POST /api/v1/votes/{voteId}/comments`)
  * 본문, 익명 여부 입력값 검증
  * 투표 등록자 또는 유효 응답(1, 2) 투표 참여자만 댓글 작성 가능하도록 권한 체크
  * 익명 댓글 작성 시 투표별 익명 번호 할당 및 재사용
  * 댓글 내용 XSS 필터링 적용
  * 댓글 작성 성공 시 상세 정보 반환
* 댓글 작성 관련 통합 테스트 작성
  * 권한/유효성/익명번호/실명/실패 케이스 포함

## 🧪 테스트

* 통합 테스트, Postman 테스트, DB 수동 검증 완료
* [x] 정상 댓글 작성 (등록자/참여자, 실명/익명)
* [x] 권한 없음(미참여/기권) 예외
* [x] 본문 유효성 실패(빈값/길이 초과) 예외
* [x] 익명 번호 할당/재사용 및 혼합 케이스

## 💬 기타 논의 사항

* Prod 데이터베이스에 테이블 수동 생성 완료