### PR TITLE
feat: 댓글 목록 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
   testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+  testImplementation 'com.jayway.jsonpath:json-path'
 
   // Prometheus / Micrometer
   implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/src/main/java/com/moa/moa_server/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/controller/CommentController.java
@@ -35,8 +35,11 @@ public class CommentController {
   @Operation(summary = "댓글 목록 조회", description = "투표에 대한 댓글 목록을 조회합니다.")
   @GetMapping("/votes/{voteId}/comments")
   public ResponseEntity<ApiResponse<CommentListResponse>> getComments(
-      @AuthenticationPrincipal Long userId, @PathVariable Long voteId) {
-    CommentListResponse response = commentService.getComments(userId, voteId);
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long voteId,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) Integer size) {
+    CommentListResponse response = commentService.getComments(userId, voteId, cursor, size);
     return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/controller/CommentController.java
@@ -2,6 +2,7 @@ package com.moa.moa_server.domain.comment.controller;
 
 import com.moa.moa_server.domain.comment.dto.request.CommentCreateRequest;
 import com.moa.moa_server.domain.comment.dto.response.CommentCreateResponse;
+import com.moa.moa_server.domain.comment.dto.response.CommentListResponse;
 import com.moa.moa_server.domain.comment.service.CommentService;
 import com.moa.moa_server.domain.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,5 +30,13 @@ public class CommentController {
       @RequestBody @Valid CommentCreateRequest request) {
     CommentCreateResponse response = commentService.createComment(userId, voteId, request);
     return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("SUCCESS", response));
+  }
+
+  @Operation(summary = "댓글 목록 조회", description = "투표에 대한 댓글 목록을 조회합니다.")
+  @GetMapping("/votes/{voteId}/comments")
+  public ResponseEntity<ApiResponse<CommentListResponse>> getComments(
+      @AuthenticationPrincipal Long userId, @PathVariable Long voteId) {
+    CommentListResponse response = commentService.getComments(userId, voteId);
+    return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/comment/dto/response/CommentItem.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/dto/response/CommentItem.java
@@ -1,0 +1,14 @@
+package com.moa.moa_server.domain.comment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "댓글 정보")
+public record CommentItem(
+    @Schema(description = "댓글 ID", example = "42") Long commentId,
+    @Schema(description = "댓글 내용", example = "저도 그렇게 생각해요.") String content,
+    @Schema(description = "댓글 작성자 닉네임", example = "익명1") String authorNickname,
+    @Schema(description = "댓글 작성 시각", example = "2025-04-22T14:30:00") LocalDateTime createdAt,
+    @Schema(description = "사용자가 댓글 작성자인지 여부", example = "true") boolean isMine,
+    @Schema(description = "숨겨진 댓글 여부", example = "false") boolean hidden,
+    @Schema(description = "사용자가 댓글을 신고했는지 여부", example = "false") boolean reportByUser) {}

--- a/src/main/java/com/moa/moa_server/domain/comment/dto/response/CommentItem.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/dto/response/CommentItem.java
@@ -1,5 +1,8 @@
 package com.moa.moa_server.domain.comment.dto.response;
 
+import com.moa.moa_server.domain.comment.entity.Comment;
+import com.moa.moa_server.domain.comment.util.CommentNicknameUtil;
+import com.moa.moa_server.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
@@ -11,4 +14,21 @@ public record CommentItem(
     @Schema(description = "댓글 작성 시각", example = "2025-04-22T14:30:00") LocalDateTime createdAt,
     @Schema(description = "사용자가 댓글 작성자인지 여부", example = "true") boolean isMine,
     @Schema(description = "숨겨진 댓글 여부", example = "false") boolean hidden,
-    @Schema(description = "사용자가 댓글을 신고했는지 여부", example = "false") boolean reportByUser) {}
+    @Schema(description = "사용자가 댓글을 신고했는지 여부", example = "false") boolean reportByUser) {
+
+  public static CommentItem of(Comment comment, User currentUser) {
+    boolean isMine = comment.getUser().getId().equals(currentUser.getId());
+    boolean hidden = comment.isHidden();
+    boolean reportedByUser = false; // (추후 구현)
+    String content = hidden ? "이 댓글은 숨김 처리되었습니다." : comment.getContent();
+    String authorNickname = CommentNicknameUtil.fromComment(comment);
+    return new CommentItem(
+        comment.getId(),
+        content,
+        authorNickname,
+        comment.getCreatedAt(),
+        isMine,
+        hidden,
+        reportedByUser);
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/comment/dto/response/CommentListResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/dto/response/CommentListResponse.java
@@ -1,0 +1,13 @@
+package com.moa.moa_server.domain.comment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "댓글 목록 조회 응답 DTO")
+public record CommentListResponse(
+    @Schema(description = "투표 ID") Long voteId,
+    @Schema(description = "댓글 목록") List<CommentItem> comments,
+    @Schema(description = "현재 페이지의 마지막 항목 기준 커서", example = "2025-04-21T12:00:00_123")
+        String nextCursor,
+    @Schema(description = "다음 페이지 여부", example = "false") boolean hasNext,
+    @Schema(description = "현재 받아온 리스트 길이", example = "10") int size) {}

--- a/src/main/java/com/moa/moa_server/domain/comment/handler/CommentErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/handler/CommentErrorCode.java
@@ -5,8 +5,10 @@ import org.springframework.http.HttpStatus;
 
 public enum CommentErrorCode implements BaseErrorCode {
   INVALID_CONTENT(HttpStatus.BAD_REQUEST),
+  INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST),
   FORBIDDEN(HttpStatus.FORBIDDEN),
-  VOTE_NOT_FOUND(HttpStatus.NOT_FOUND);
+  VOTE_NOT_FOUND(HttpStatus.NOT_FOUND),
+  ;
 
   private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,11 @@
 package com.moa.moa_server.domain.comment.repository;
 
 import com.moa.moa_server.domain.comment.entity.Comment;
+import com.moa.moa_server.domain.global.cursor.CreatedAtCommentIdCursor;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,4 +15,26 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
       "SELECT c.anonymousNumber FROM Comment c WHERE c.vote.id = :voteId AND c.user.id = :userId AND c.anonymousNumber > 0 ORDER BY c.createdAt ASC")
   Integer findFirstAnonymousNumberByVoteIdAndUserId(
       @Param("voteId") Long voteId, @Param("userId") Long userId);
+
+  @Query(
+      """
+    SELECT c FROM Comment c
+    WHERE c.vote.id = :voteId
+      AND c.deletedAt IS NULL
+      AND (c.createdAt > :createdAt OR (c.createdAt = :createdAt AND c.id > :commentId))
+    ORDER BY c.createdAt ASC, c.id ASC
+""")
+  List<Comment> findByVoteIdAfterCursor(
+      @Param("voteId") Long voteId,
+      @Param("createdAt") LocalDateTime createdAt,
+      @Param("commentId") Long commentId,
+      Pageable pageable);
+
+  default List<Comment> findComments(Vote vote, CreatedAtCommentIdCursor cursor, int size) {
+    LocalDateTime createdAt = (cursor != null) ? cursor.createdAt() : null;
+    Long commentId = (cursor != null) ? cursor.commentId() : 0L;
+    Pageable pageable =
+        org.springframework.data.domain.PageRequest.of(0, size + 1); // hasNext 판단 위해 +1
+    return findByVoteIdAfterCursor(vote.getId(), createdAt, commentId, pageable);
+  }
 }

--- a/src/main/java/com/moa/moa_server/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/repository/CommentRepository.java
@@ -1,40 +1,13 @@
 package com.moa.moa_server.domain.comment.repository;
 
 import com.moa.moa_server.domain.comment.entity.Comment;
-import com.moa.moa_server.domain.global.cursor.CreatedAtCommentIdCursor;
-import com.moa.moa_server.domain.vote.entity.Vote;
-import java.time.LocalDateTime;
-import java.util.List;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
   @Query(
       "SELECT c.anonymousNumber FROM Comment c WHERE c.vote.id = :voteId AND c.user.id = :userId AND c.anonymousNumber > 0 ORDER BY c.createdAt ASC")
   Integer findFirstAnonymousNumberByVoteIdAndUserId(
       @Param("voteId") Long voteId, @Param("userId") Long userId);
-
-  @Query(
-      """
-    SELECT c FROM Comment c
-    WHERE c.vote.id = :voteId
-      AND c.deletedAt IS NULL
-      AND (c.createdAt > :createdAt OR (c.createdAt = :createdAt AND c.id > :commentId))
-    ORDER BY c.createdAt ASC, c.id ASC
-""")
-  List<Comment> findByVoteIdAfterCursor(
-      @Param("voteId") Long voteId,
-      @Param("createdAt") LocalDateTime createdAt,
-      @Param("commentId") Long commentId,
-      Pageable pageable);
-
-  default List<Comment> findComments(Vote vote, CreatedAtCommentIdCursor cursor, int size) {
-    LocalDateTime createdAt = (cursor != null) ? cursor.createdAt() : null;
-    Long commentId = (cursor != null) ? cursor.commentId() : 0L;
-    Pageable pageable =
-        org.springframework.data.domain.PageRequest.of(0, size + 1); // hasNext 판단 위해 +1
-    return findByVoteIdAfterCursor(vote.getId(), createdAt, commentId, pageable);
-  }
 }

--- a/src/main/java/com/moa/moa_server/domain/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/repository/CommentRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.moa.moa_server.domain.comment.repository;
+
+import com.moa.moa_server.domain.comment.entity.Comment;
+import com.moa.moa_server.domain.global.cursor.CreatedAtCommentIdCursor;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import jakarta.annotation.Nullable;
+import java.util.List;
+
+public interface CommentRepositoryCustom {
+  List<Comment> findByVoteWithCursor(
+      Vote vote, @Nullable CreatedAtCommentIdCursor cursor, int size);
+}

--- a/src/main/java/com/moa/moa_server/domain/comment/repository/impl/CommentRepositoryImpl.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/repository/impl/CommentRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.moa.moa_server.domain.comment.repository.impl;
+
+import com.moa.moa_server.domain.comment.entity.Comment;
+import com.moa.moa_server.domain.comment.entity.QComment;
+import com.moa.moa_server.domain.comment.repository.CommentRepositoryCustom;
+import com.moa.moa_server.domain.global.cursor.CreatedAtCommentIdCursor;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Comment> findByVoteWithCursor(
+      Vote vote, @Nullable CreatedAtCommentIdCursor cursor, int size) {
+    QComment comment = QComment.comment;
+
+    BooleanBuilder builder =
+        new BooleanBuilder().and(comment.vote.eq(vote)).and(comment.deletedAt.isNull());
+
+    if (cursor != null) {
+      builder.and(
+          comment
+              .createdAt
+              .gt(cursor.createdAt())
+              .or(comment.createdAt.eq(cursor.createdAt()).and(comment.id.gt(cursor.commentId()))));
+    }
+
+    return queryFactory
+        .selectFrom(comment)
+        .where(builder)
+        .orderBy(comment.createdAt.asc(), comment.id.asc())
+        .limit(size + 1)
+        .fetch();
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/comment/service/CommentService.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/service/CommentService.java
@@ -2,6 +2,7 @@ package com.moa.moa_server.domain.comment.service;
 
 import com.moa.moa_server.domain.comment.dto.request.CommentCreateRequest;
 import com.moa.moa_server.domain.comment.dto.response.CommentCreateResponse;
+import com.moa.moa_server.domain.comment.dto.response.CommentListResponse;
 import com.moa.moa_server.domain.comment.entity.Comment;
 import com.moa.moa_server.domain.comment.handler.CommentErrorCode;
 import com.moa.moa_server.domain.comment.handler.CommentException;
@@ -76,6 +77,10 @@ public class CommentService {
 
     return new CommentCreateResponse(
         comment.getId(), comment.getContent(), authorNickname, comment.getCreatedAt());
+  }
+
+  public CommentListResponse getComments(Long userId, Long voteId) {
+    return null;
   }
 
   /** 댓글 테이블에서 익명 번호 조회 및 할당 */

--- a/src/main/java/com/moa/moa_server/domain/comment/service/CommentService.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/service/CommentService.java
@@ -117,7 +117,7 @@ public class CommentService {
     }
 
     // 댓글 목록 조회
-    List<Comment> comments = commentRepository.findComments(vote, parsedCursor, pageSize);
+    List<Comment> comments = commentRepository.findByVoteWithCursor(vote, parsedCursor, pageSize);
 
     // 응답 구성 (nextCursor, hasNext 계산)
     boolean hasNext = comments.size() > pageSize;

--- a/src/main/java/com/moa/moa_server/domain/comment/service/CommentService.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/service/CommentService.java
@@ -2,11 +2,14 @@ package com.moa.moa_server.domain.comment.service;
 
 import com.moa.moa_server.domain.comment.dto.request.CommentCreateRequest;
 import com.moa.moa_server.domain.comment.dto.response.CommentCreateResponse;
+import com.moa.moa_server.domain.comment.dto.response.CommentItem;
 import com.moa.moa_server.domain.comment.dto.response.CommentListResponse;
 import com.moa.moa_server.domain.comment.entity.Comment;
 import com.moa.moa_server.domain.comment.handler.CommentErrorCode;
 import com.moa.moa_server.domain.comment.handler.CommentException;
 import com.moa.moa_server.domain.comment.repository.CommentRepository;
+import com.moa.moa_server.domain.comment.util.CommentNicknameUtil;
+import com.moa.moa_server.domain.global.cursor.CreatedAtCommentIdCursor;
 import com.moa.moa_server.domain.global.util.XssUtil;
 import com.moa.moa_server.domain.user.entity.User;
 import com.moa.moa_server.domain.user.handler.UserErrorCode;
@@ -16,6 +19,7 @@ import com.moa.moa_server.domain.user.util.AuthUserValidator;
 import com.moa.moa_server.domain.vote.entity.Vote;
 import com.moa.moa_server.domain.vote.repository.VoteRepository;
 import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
+import jakarta.annotation.Nullable;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class CommentService {
+
+  private static final int DEFAULT_PAGE_SIZE = 10;
 
   private final CommentRepository commentRepository;
   private final UserRepository userRepository;
@@ -73,14 +79,62 @@ public class CommentService {
 
     // authorNickname (익명1 or 닉네임)
     String authorNickname =
-        getAuthorNickname(request.anonymous(), anonymousNumber, user.getNickname());
+        CommentNicknameUtil.generateNickname(
+            request.anonymous(), anonymousNumber, user.getNickname());
 
     return new CommentCreateResponse(
         comment.getId(), comment.getContent(), authorNickname, comment.getCreatedAt());
   }
 
-  public CommentListResponse getComments(Long userId, Long voteId) {
-    return null;
+  @Transactional(readOnly = true)
+  public CommentListResponse getComments(
+      Long userId, Long voteId, @Nullable String cursor, @Nullable Integer size) {
+    int pageSize = (size == null || size <= 0) ? DEFAULT_PAGE_SIZE : size;
+    CreatedAtCommentIdCursor parsedCursor =
+        cursor != null ? CreatedAtCommentIdCursor.parse(cursor) : null;
+
+    // 유저 조회 및 유효성 검사
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    AuthUserValidator.validateActive(user);
+
+    // 투표 존재 확인
+    Vote vote =
+        voteRepository
+            .findById(voteId)
+            .orElseThrow(() -> new CommentException(CommentErrorCode.VOTE_NOT_FOUND));
+
+    // 댓글 조회 권한 확인 (투표 참여자(유효 응답: 1, 2)이거나 투표 등록자)
+    // TODO: 권한 추가 - top3 투표인 경우 모든 사용자가 댓글 작성 가능
+    boolean isOwner = vote.getUser().getId().equals(user.getId());
+    boolean isParticipant =
+        voteResponseRepository.existsByVoteIdAndUserIdAndOptionNumberIn(
+            voteId, userId, List.of(1, 2));
+    if (!(isOwner || isParticipant)) {
+      throw new CommentException(CommentErrorCode.FORBIDDEN);
+    }
+
+    // 댓글 목록 조회
+    List<Comment> comments = commentRepository.findComments(vote, parsedCursor, pageSize);
+
+    // 응답 구성 (nextCursor, hasNext 계산)
+    boolean hasNext = comments.size() > pageSize;
+    if (hasNext) comments = comments.subList(0, pageSize);
+
+    String nextCursor =
+        hasNext
+            ? new CreatedAtCommentIdCursor(
+                    comments.getLast().getCreatedAt(), comments.getLast().getId())
+                .encode()
+            : null;
+
+    List<CommentItem> items =
+        comments.stream().map(comment -> CommentItem.of(comment, user)).toList();
+
+    // 응답
+    return new CommentListResponse(voteId, items, nextCursor, hasNext, items.size());
   }
 
   /** 댓글 테이블에서 익명 번호 조회 및 할당 */
@@ -94,10 +148,5 @@ public class CommentService {
     int nextNumber = vote.increaseLastAnonymousNumber();
     voteRepository.save(vote);
     return nextNumber;
-  }
-
-  /** 댓글 작성자 닉네임 생성 */
-  private String getAuthorNickname(boolean anonymous, int anonymousNumber, String nickname) {
-    return anonymous ? "익명" + anonymousNumber : nickname;
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/comment/util/CommentNicknameUtil.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/util/CommentNicknameUtil.java
@@ -1,0 +1,17 @@
+package com.moa.moa_server.domain.comment.util;
+
+import com.moa.moa_server.domain.comment.entity.Comment;
+
+public class CommentNicknameUtil {
+  /** 댓글/유저/익명여부 기반 닉네임 생성 */
+  public static String generateNickname(boolean anonymous, int anonymousNumber, String nickname) {
+    return anonymous ? "익명" + anonymousNumber : nickname;
+  }
+
+  /** Comment 엔티티 기반 닉네임 생성 (CommentItem.of에서 사용) */
+  public static String fromComment(Comment comment) {
+    return comment.getAnonymousNumber() > 0
+        ? "익명" + comment.getAnonymousNumber()
+        : comment.getUser().getNickname();
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/global/cursor/CreatedAtCommentIdCursor.java
+++ b/src/main/java/com/moa/moa_server/domain/global/cursor/CreatedAtCommentIdCursor.java
@@ -1,0 +1,28 @@
+package com.moa.moa_server.domain.global.cursor;
+
+import com.moa.moa_server.domain.comment.handler.CommentErrorCode;
+import com.moa.moa_server.domain.comment.handler.CommentException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public record CreatedAtCommentIdCursor(LocalDateTime createdAt, Long commentId) {
+
+  /** "createdAt_commentId" 형식의 커서를 파싱 */
+  public static CreatedAtCommentIdCursor parse(String cursor) {
+    try {
+      String[] parts = cursor.split("_");
+      if (parts.length != 2) {
+        throw new CommentException(CommentErrorCode.INVALID_CURSOR_FORMAT);
+      }
+      return new CreatedAtCommentIdCursor(LocalDateTime.parse(parts[0]), Long.parseLong(parts[1]));
+    } catch (DateTimeParseException | NumberFormatException e) {
+      throw new CommentException(CommentErrorCode.INVALID_CURSOR_FORMAT);
+    }
+  }
+
+  public String encode() {
+    DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+    return createdAt.format(formatter) + "_" + commentId;
+  }
+}

--- a/src/test/java/com/moa/moa_server/integration/comment/CommentListIntegrationTest.java
+++ b/src/test/java/com/moa/moa_server/integration/comment/CommentListIntegrationTest.java
@@ -1,0 +1,233 @@
+package com.moa.moa_server.integration.comment;
+
+import static com.moa.moa_server.util.TestFixture.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import com.moa.moa_server.domain.auth.service.JwtTokenService;
+import com.moa.moa_server.domain.comment.handler.CommentErrorCode;
+import com.moa.moa_server.domain.comment.repository.CommentRepository;
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.repository.GroupRepository;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.repository.VoteRepository;
+import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+public class CommentListIntegrationTest {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired UserRepository userRepository;
+  @Autowired GroupRepository groupRepository;
+  @Autowired VoteRepository voteRepository;
+  @Autowired VoteResponseRepository voteResponseRepository;
+  @Autowired JwtTokenService jwtTokenService;
+
+  User testUser;
+  Group testGroup;
+  Vote testVote;
+  String accessToken;
+  @Autowired private CommentRepository commentRepository;
+
+  @BeforeEach
+  void setup() {
+    testUser = userRepository.save(user("testuser"));
+    testGroup = groupRepository.save(group(testUser, "공개"));
+    testVote = voteRepository.save(vote(testUser, testGroup, Vote.VoteStatus.OPEN));
+    accessToken = jwtTokenService.issueAccessToken(testUser.getId());
+    // 댓글 12개 등록
+    for (int i = 1; i <= 12; i++) {
+      commentRepository.save(comment(testVote, testUser, "댓글 " + i, 0));
+    }
+  }
+
+  @Nested
+  class 성공_케이스 {
+
+    @Test
+    @DisplayName("페이지네이션 기본 동작")
+    void getCommentList_basicPagination() throws Exception {
+      // 첫 페이지 요청 (size=10)
+      mockMvc
+          .perform(
+              get("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + accessToken)
+                  .param("size", "10"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.data.comments.length()").value(10))
+          .andExpect(jsonPath("$.data.hasNext").value(true))
+          .andExpect(jsonPath("$.data.nextCursor").exists())
+          .andExpect(jsonPath("$.data.size").value(10));
+    }
+
+    @Test
+    @DisplayName("커서 기반 다음 페이지 조회")
+    void getCommentList_withCursor() throws Exception {
+      System.out.println("현재 등록된 댓글 수: " + commentRepository.count());
+      commentRepository
+          .findAll()
+          .forEach(
+              c -> System.out.println(c.getId() + " " + c.getContent() + " " + c.getCreatedAt()));
+
+      // 1. 첫 페이지 요청
+      String firstPageResponse =
+          mockMvc
+              .perform(
+                  get("/api/v1/votes/{voteId}/comments", testVote.getId())
+                      .header("Authorization", "Bearer " + accessToken)
+                      .param("size", "10"))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+      System.out.println("첫 페이지 응답: " + firstPageResponse);
+
+      // 2. nextCursor 파싱
+      String nextCursor = JsonPath.read(firstPageResponse, "$.data.nextCursor");
+      System.out.println("nextCursor: " + nextCursor);
+
+      // 3. 두 번째 페이지 요청
+      mockMvc
+          .perform(
+              get("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + accessToken)
+                  .param("cursor", nextCursor)
+                  .param("size", "10"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.data.comments.length()").value(2))
+          .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    // 삭제된 댓글 제외 확인
+    // TO DO: 댓글 삭제 기능 구현 시 작성
+    //    @Test
+    //    @DisplayName("삭제 댓글은 응답에 포함되지 않음")
+    //    void getCommentList_deletedCommentExcluded() throws Exception {
+    //      // 댓글 하나 soft delete
+    //      Comment toDelete = commentRepository.findAll().getFirst();
+    //      toDelete.delete(); // soft delete 메서드 구현 필요
+    //      commentRepository.save(toDelete);
+    //
+    //      // when & then
+    //      mockMvc.perform(get("/api/v1/votes/{voteId}/comments", testVote.getId())
+    //          .header("Authorization", "Bearer " + accessToken))
+    //        .andExpect(status().isOk())
+    //        .andExpect(jsonPath("$.data.comments.length()").value(9)); // 삭제된 거 1개 빠짐
+    //    }
+
+    @Test
+    @DisplayName("댓글 작성자 여부 isMine 필드 확인")
+    void getCommentList_isMineField() throws Exception {
+      // given
+      // 본인 댓글 1개, 다른 유저 댓글 1개 추가
+      User otherUser = userRepository.save(user("otheruser"));
+      commentRepository.save(comment(testVote, otherUser, "다른 사람 댓글", 0));
+
+      // when & then
+      mockMvc
+          .perform(
+              get("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + accessToken)
+                  .param("size", "15"))
+          .andExpect(status().isOk())
+          // 본인 댓글: isMine == true
+          .andExpect(jsonPath("$.data.comments[?(@.content=='댓글 1')].isMine").value(true))
+          // 다른 사람 댓글: isMine == false
+          .andExpect(jsonPath("$.data.comments[?(@.content=='다른 사람 댓글')].isMine").value(false));
+    }
+  }
+
+  @Nested
+  class 실패_케이스 {
+    // 테스트 케이스
+    // 권한 없음 ✅
+    // 투표가 없는 경우 ✅
+    // 잘못된 커서 포맷 ✅
+    // size 파라미터 0, 음수, 1000
+
+    @Test
+    @DisplayName("권한 없는 유저 (투표 참여자나 투표 등록자가 아님)")
+    void getCommentList_forbidden_notParticipant() throws Exception {
+      // given
+      User stranger = userRepository.save(user("stranger"));
+      String strangerToken = jwtTokenService.issueAccessToken(stranger.getId());
+
+      // when & then
+      mockMvc
+          .perform(
+              get("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + strangerToken))
+          .andExpect(status().isForbidden())
+          .andExpect(jsonPath("$.message").value(CommentErrorCode.FORBIDDEN.name()));
+    }
+
+    @Test
+    @DisplayName("권한 없는 유저 (투표 참여자지만 유효하지 않은 응답(option=0, 기권))")
+    void getCommentList_forbidden_invalidParticipant() throws Exception {
+      // given
+      User stranger = userRepository.save(user("stranger"));
+      String strangerToken = jwtTokenService.issueAccessToken(stranger.getId());
+      voteResponseRepository.save(voteResponse(testVote, stranger, 0));
+
+      // when & then
+      mockMvc
+          .perform(
+              get("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + strangerToken))
+          .andExpect(status().isForbidden())
+          .andExpect(jsonPath("$.message").value(CommentErrorCode.FORBIDDEN.name()));
+    }
+
+    @Test
+    @DisplayName("투표가 존재하지 않음")
+    void getCommentList_notFound() throws Exception {
+      mockMvc
+          .perform(
+              get("/api/v1/votes/{voteId}/comments", 9999L)
+                  .header("Authorization", "Bearer " + accessToken))
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.message").value(CommentErrorCode.VOTE_NOT_FOUND.name()));
+    }
+
+    // TO DO: 투표 삭제 기능 추가 시 작성하기
+    //    @Test
+    //    @DisplayName("삭제된 투표")
+    //    void getCommentList_deletedVote() throws Exception {
+    //      // 투표 soft delete 처리
+    //
+    //      mockMvc.perform(get("/api/v1/votes/{voteId}/comments", testVote.getId())
+    //          .header("Authorization", "Bearer " + accessToken))
+    //        .andExpect(status().isNotFound())
+    //        .andExpect(jsonPath("$.message").value(CommentErrorCode.VOTE_NOT_FOUND.name()));
+    //    }
+
+    @Test
+    @DisplayName("커서 포맷 에러 - 400 반환")
+    void getCommentList_invalidCursor() throws Exception {
+      mockMvc
+          .perform(
+              get("/api/v1/votes/{voteId}/comments", testVote.getId())
+                  .header("Authorization", "Bearer " + accessToken)
+                  .param("cursor", "invalid_cursor_format"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message").value(CommentErrorCode.INVALID_CURSOR_FORMAT.name()));
+    }
+  }
+}

--- a/src/test/java/com/moa/moa_server/util/TestFixture.java
+++ b/src/test/java/com/moa/moa_server/util/TestFixture.java
@@ -1,5 +1,6 @@
 package com.moa.moa_server.util;
 
+import com.moa.moa_server.domain.comment.entity.Comment;
 import com.moa.moa_server.domain.group.entity.Group;
 import com.moa.moa_server.domain.user.entity.User;
 import com.moa.moa_server.domain.vote.entity.Vote;
@@ -33,5 +34,9 @@ public class TestFixture {
 
   public static VoteResponse voteResponse(Vote vote, User user, int option) {
     return VoteResponse.builder().vote(vote).user(user).optionNumber(option).build();
+  }
+
+  public static Comment comment(Vote vote, User user, String content, int anonymousNumber) {
+    return Comment.create(user, vote, content, anonymousNumber);
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈

* Closes #191

## 🔥 작업 개요

* 댓글 목록 조회 API 구현

## 🛠️ 작업 상세

* 댓글 목록 조회 API 구현 (`GET /api/v1/votes/{voteId}/comments`)
  * 커서 기반 페이지네이션 (createdAt, commentId 조합)
  * 투표 등록자 또는 유효 응답(1, 2) 투표 참여자만 조회 가능하도록 권한 체크
  * 숨김/삭제 댓글 처리(숨김 사유 메시지 등)
  * 댓글 작성자 여부(isMine), 익명 닉네임, 신고 여부 등 상세 정보 포함
* 통합 테스트 코드 작성 (권한/커서/예외/숨김/작성자 등)

## 🧪 테스트

* 통합 테스트, Postman 테스트 완료
* [x] 기본 페이지네이션, 커서 기반 페이징, hasNext/nextCursor 반환
* [x] 권한 없음(비참여/기권) 예외 처리
* [x] isMine, 익명/실명 닉네임 필드 검증

## 💬 기타 논의 사항

* 없음