### PR TITLE
feat: 카카오 로그인 시 닉네임, 이메일 저장 추가

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/auth/dto/model/KakaoUserInfo.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/dto/model/KakaoUserInfo.java
@@ -1,0 +1,3 @@
+package com.moa.moa_server.domain.auth.dto.model;
+
+public record KakaoUserInfo(String id, String email, String nickname) {}

--- a/src/main/java/com/moa/moa_server/domain/auth/entity/OAuth.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/entity/OAuth.java
@@ -27,11 +27,18 @@ public class OAuth {
   @Column(name = "provider_code", length = 20, nullable = false)
   private ProviderCode providerCode;
 
+  @Column(name = "oauth_nickname", length = 200)
+  private String oauthNickname;
+
   public enum ProviderCode {
     KAKAO;
 
     public static boolean isSupported(String provider) {
       return Arrays.stream(values()).anyMatch(p -> p.name().equalsIgnoreCase(provider));
     }
+  }
+
+  public void updateOauthNickname(String nickname) {
+    this.oauthNickname = nickname;
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/auth/repository/OAuthRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/repository/OAuthRepository.java
@@ -2,6 +2,7 @@ package com.moa.moa_server.domain.auth.repository;
 
 import com.moa.moa_server.domain.auth.entity.OAuth;
 import com.moa.moa_server.domain.user.entity.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.lang.NonNull;
@@ -13,4 +14,6 @@ public interface OAuthRepository extends JpaRepository<OAuth, Long> {
   void deleteByUserId(Long userId);
 
   Optional<OAuth> findByUser(User user);
+
+  List<OAuth> user(User user);
 }

--- a/src/main/java/com/moa/moa_server/domain/auth/service/strategy/KakaoOAuthLoginStrategy.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/service/strategy/KakaoOAuthLoginStrategy.java
@@ -1,5 +1,6 @@
 package com.moa.moa_server.domain.auth.service.strategy;
 
+import com.moa.moa_server.domain.auth.dto.model.KakaoUserInfo;
 import com.moa.moa_server.domain.auth.dto.model.LoginResult;
 import com.moa.moa_server.domain.auth.dto.response.LoginResponse;
 import com.moa.moa_server.domain.auth.entity.OAuth;
@@ -11,21 +12,22 @@ import com.moa.moa_server.domain.auth.service.RefreshTokenService;
 import com.moa.moa_server.domain.user.entity.User;
 import com.moa.moa_server.domain.user.repository.UserRepository;
 import com.moa.moa_server.domain.user.util.NicknameGenerator;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Service("kakao")
 @Slf4j
@@ -63,8 +65,8 @@ public class KakaoOAuthLoginStrategy implements OAuthLoginStrategy {
     // 인가코드로 카카오 액세스 토큰 요청
     String kakaoAccessToken = getAccessToken(code, redirectUri);
 
-    // 카카오 액세스 토큰으로 사용자 정보 요청
-    String kakaoId = getUserInfo(kakaoAccessToken);
+    // 카카오 액세스 토큰으로 카카오 ID 요청
+    String kakaoId = getKakaoId(kakaoAccessToken);
 
     // 사용자 정보 DB 조회
     Optional<OAuth> oAuthOptional = oAuthRepository.findById(kakaoId);
@@ -74,6 +76,7 @@ public class KakaoOAuthLoginStrategy implements OAuthLoginStrategy {
             .orElseGet(
                 () -> {
                   // 신규 회원가입
+                  KakaoUserInfo userInfo = getUserInfo(kakaoAccessToken);
                   String nickname = NicknameGenerator.generate(userRepository);
                   User newUser =
                       User.builder()
@@ -81,13 +84,17 @@ public class KakaoOAuthLoginStrategy implements OAuthLoginStrategy {
                           .role(User.Role.USER)
                           .userStatus(User.UserStatus.ACTIVE)
                           .lastActiveAt(LocalDateTime.now())
-                          .email(null)
+                          .email(userInfo.email())
                           .withdrawn_at(null)
                           .build();
                   userRepository.save(newUser);
-                  oAuthRepository.save(new OAuth(kakaoId, newUser, OAuth.ProviderCode.KAKAO));
+                  oAuthRepository.save(
+                      new OAuth(kakaoId, newUser, OAuth.ProviderCode.KAKAO, userInfo.nickname()));
                   return newUser;
                 });
+
+    // 기존 회원이라면 누락된 oauthNickname, email 보완
+    updateMissingUserInfo(user, oAuthOptional.orElse(null), kakaoAccessToken);
 
     // 자체 액세스 토큰과 리프레시 토큰 발급
     String accessToken = jwtTokenService.issueAccessToken(user.getId());
@@ -98,6 +105,7 @@ public class KakaoOAuthLoginStrategy implements OAuthLoginStrategy {
     return new LoginResult(loginResponseDto, refreshToken);
   }
 
+  /** 카카오 로그인 토큰 받기를 통해 카카오 액세스 토큰을 가져온다. */
   private String getAccessToken(String code, String redirectUri) {
 
     HttpHeaders headers = new HttpHeaders();
@@ -119,7 +127,8 @@ public class KakaoOAuthLoginStrategy implements OAuthLoginStrategy {
     }
   }
 
-  private String getUserInfo(String accessToken) {
+  /** 카카오 사용자 정보 요청하기를 통해 id(회원번호)를 받아온다. */
+  private String getKakaoId(String accessToken) {
 
     HttpHeaders headers = new HttpHeaders();
     headers.setBearerAuth(accessToken);
@@ -134,6 +143,66 @@ public class KakaoOAuthLoginStrategy implements OAuthLoginStrategy {
       return String.valueOf(kakaoId);
     } catch (Exception e) {
       throw new AuthException(AuthErrorCode.KAKAO_USERINFO_FAILED);
+    }
+  }
+
+  /** 카카오 사용자 정보 가져오기를 통해 카카오 이메일, 닉네임을 가져온다. */
+  private KakaoUserInfo getUserInfo(String accessToken) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(accessToken);
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    String jsonArray = "[\"kakao_account.email\",\"kakao_account.profile\"]";
+    String encoded = URLEncoder.encode(jsonArray, StandardCharsets.UTF_8);
+    URI uri =
+        UriComponentsBuilder.fromUri(URI.create(kakaoUserInfoUri))
+            .queryParam("property_keys", encoded)
+            .build(true)
+            .toUri();
+
+    HttpEntity<Void> request = new HttpEntity<>(headers);
+
+    try {
+      ResponseEntity<Map> response =
+          restTemplate.exchange(uri, HttpMethod.POST, request, Map.class);
+      Map<String, Object> body = response.getBody();
+
+      log.info("카카오 사용자 정보 응답: {}", body);
+
+      String id = String.valueOf(body.get("id"));
+
+      Map<String, Object> kakaoAccount = (Map<String, Object>) body.get("kakao_account");
+      String email = (String) kakaoAccount.get("email");
+
+      Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+      String nickname = (String) profile.get("nickname");
+
+      return new KakaoUserInfo(id, email, nickname);
+    } catch (Exception e) {
+      throw new AuthException(AuthErrorCode.KAKAO_USERINFO_FAILED);
+    }
+  }
+
+  /** 기존 회원의 oauthNickname 또는 email이 비어있을 경우 카카오에서 가져온 정보를 저장 */
+  private void updateMissingUserInfo(User user, OAuth oAuth, String kakaoAccessToken) {
+    // 이메일이 비어 있으면 user 업데이트 대상
+    boolean updateUserEmail = user.getEmail() == null;
+
+    // oAuth 객체가 존재하고 닉네임이 비어 있으면 oAuth 업데이트 대상
+    boolean updateOauthNickname = oAuth != null && oAuth.getOauthNickname() == null;
+
+    if (updateUserEmail || updateOauthNickname) {
+      KakaoUserInfo userInfo = getUserInfo(kakaoAccessToken);
+
+      if (updateUserEmail && userInfo.email() != null) {
+        user.updateEmail(userInfo.email());
+        userRepository.save(user);
+      }
+
+      if (updateOauthNickname && userInfo.nickname() != null) {
+        oAuth.updateOauthNickname(userInfo.nickname());
+        oAuthRepository.save(oAuth);
+      }
     }
   }
 

--- a/src/main/java/com/moa/moa_server/domain/user/entity/User.java
+++ b/src/main/java/com/moa/moa_server/domain/user/entity/User.java
@@ -52,6 +52,10 @@ public class User extends BaseTimeEntity {
     this.nickname = nickname;
   }
 
+  public void updateEmail(String email) {
+    this.email = email;
+  }
+
   public void withdraw() {
     this.userStatus = UserStatus.WITHDRAWN;
     this.withdrawn_at = LocalDateTime.now();


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #200

## 🔥 작업 개요
- 카카오 로그인 연동 시 카카오 계정의 닉네임과 이메일을 함께 저장하도록 개선

## 🛠️ 작업 상세
- 카카오 로그인 시, 카카오에서 제공하는 닉네임과 이메일 정보를 받아와 DB에 저장
   - 신규 회원가입 시 닉네임/이메일 모두 저장
   - 기존 회원인 경우 닉네임/이메일 정보가 누락되어 있으면 보완
- `OAuth` 테이블 `oauth_nickname` 컬럼 추가

## 🧪 테스트

* [x] 신규 카카오 계정으로 회원가입 시 닉네임, 이메일 정상 저장 여부 확인
* [x] 기존 회원이 누락된 정보 보완되는지 확인
  
## 💬 기타 논의 사항

* Prod 데이터베이스에 `oauth_nickname` 필드 추가 필요
