### PR TITLE
feat: 댓글 삭제 API 구현

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/controller/CommentController.java
@@ -2,6 +2,7 @@ package com.moa.moa_server.domain.comment.controller;
 
 import com.moa.moa_server.domain.comment.dto.request.CommentCreateRequest;
 import com.moa.moa_server.domain.comment.dto.response.CommentCreateResponse;
+import com.moa.moa_server.domain.comment.dto.response.CommentDeleteResponse;
 import com.moa.moa_server.domain.comment.dto.response.CommentListResponse;
 import com.moa.moa_server.domain.comment.service.CommentService;
 import com.moa.moa_server.domain.global.dto.ApiResponse;
@@ -40,6 +41,14 @@ public class CommentController {
       @RequestParam(required = false) String cursor,
       @RequestParam(required = false) Integer size) {
     CommentListResponse response = commentService.getComments(userId, voteId, cursor, size);
+    return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
+  }
+
+  @Operation(summary = "댓글 삭제", description = "작성한 댓글을 삭제합니다.")
+  @DeleteMapping("/comments/{commentId}")
+  public ResponseEntity<ApiResponse<CommentDeleteResponse>> deleteComment(
+      @AuthenticationPrincipal Long userId, @PathVariable Long commentId) {
+    CommentDeleteResponse response = commentService.deleteComment(userId, commentId);
     return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/comment/dto/response/CommentDeleteResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/dto/response/CommentDeleteResponse.java
@@ -1,0 +1,7 @@
+package com.moa.moa_server.domain.comment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "댓글 삭제 응답 DTO")
+public record CommentDeleteResponse(
+    @Schema(description = "삭제된 댓글 ID", example = "42") Long commentId) {}

--- a/src/main/java/com/moa/moa_server/domain/comment/entity/Comment.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/entity/Comment.java
@@ -6,6 +6,7 @@ import com.moa.moa_server.domain.vote.entity.Vote;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.*;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
@@ -13,6 +14,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 @Table(name = "comment")
+@Where(clause = "deleted_at IS NULL")
 public class Comment extends BaseTimeEntity {
 
   @Id
@@ -59,6 +61,10 @@ public class Comment extends BaseTimeEntity {
         .hiddenByReport(false)
         .hiddenByAdmin(false)
         .build();
+  }
+
+  public void softDelete() {
+    this.deletedAt = LocalDateTime.now();
   }
 
   public boolean isDeleted() {

--- a/src/main/java/com/moa/moa_server/domain/comment/handler/CommentErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/handler/CommentErrorCode.java
@@ -8,6 +8,7 @@ public enum CommentErrorCode implements BaseErrorCode {
   INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST),
   FORBIDDEN(HttpStatus.FORBIDDEN),
   VOTE_NOT_FOUND(HttpStatus.NOT_FOUND),
+  COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/moa/moa_server/domain/comment/service/CommentService.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/service/CommentService.java
@@ -2,9 +2,12 @@ package com.moa.moa_server.domain.comment.service;
 
 import com.moa.moa_server.domain.comment.dto.request.CommentCreateRequest;
 import com.moa.moa_server.domain.comment.dto.response.CommentCreateResponse;
+import com.moa.moa_server.domain.comment.dto.response.CommentDeleteResponse;
 import com.moa.moa_server.domain.comment.dto.response.CommentItem;
 import com.moa.moa_server.domain.comment.dto.response.CommentListResponse;
 import com.moa.moa_server.domain.comment.entity.Comment;
+import com.moa.moa_server.domain.comment.handler.CommentErrorCode;
+import com.moa.moa_server.domain.comment.handler.CommentException;
 import com.moa.moa_server.domain.comment.repository.CommentRepository;
 import com.moa.moa_server.domain.comment.service.context.CommentPermissionContext;
 import com.moa.moa_server.domain.comment.service.context.CommentPermissionContextFactory;
@@ -98,6 +101,25 @@ public class CommentService {
 
     // 응답
     return new CommentListResponse(voteId, items, nextCursor, hasNext, items.size());
+  }
+
+  /** 댓글 삭제 */
+  @Transactional
+  public CommentDeleteResponse deleteComment(Long userId, Long commentId) {
+    Comment comment =
+        commentRepository
+            .findById(commentId)
+            .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+    if (!comment.getUser().getId().equals(userId)) {
+      throw new CommentException(CommentErrorCode.FORBIDDEN);
+    }
+
+    if (!comment.isDeleted()) {
+      comment.softDelete();
+    }
+
+    return new CommentDeleteResponse(commentId);
   }
 
   /** 댓글 테이블에서 익명 번호 조회 및 할당 */


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #202

## 🔥 작업 개요

- 댓글 삭제 기능 구현

## 🛠️ 작업 상세
- DELETE /api/v1/comments/{commentId} API 구현
  - 댓글 작성자 본인만 삭제 가능
  - 삭제된 댓글은 목록 조회 시 미노출 처리
- 댓글 soft delete 방식 적용 (deletedAt 필드 업데이트)


## 🧪 테스트

* [x] Postman으로 API 테스트 완료
* [x] 본인 댓글 삭제 성공
* [x] 타인 댓글 삭제 시 403 FORBIDDEN 응답 확인
* [x] 삭제된 댓글은 댓글 목록 조회 시 노출되지 않음
  
## 💬 기타 논의 사항

* 없음
