### PR TITLE
feat: 투표 삭제 API 구현

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package com.moa.moa_server.domain.comment.repository;
 
 import com.moa.moa_server.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -10,4 +11,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
       "SELECT c.anonymousNumber FROM Comment c WHERE c.vote.id = :voteId AND c.user.id = :userId AND c.anonymousNumber > 0 ORDER BY c.createdAt ASC")
   Integer findFirstAnonymousNumberByVoteIdAndUserId(
       @Param("voteId") Long voteId, @Param("userId") Long userId);
+
+  @Modifying
+  @Query("UPDATE Comment c SET c.deletedAt = CURRENT_TIMESTAMP WHERE c.vote.id = :voteId")
+  void softDeleteByVoteId(@Param("voteId") Long voteId);
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
@@ -5,10 +5,7 @@ import com.moa.moa_server.domain.global.dto.ApiResponseVoid;
 import com.moa.moa_server.domain.vote.dto.request.VoteCreateRequest;
 import com.moa.moa_server.domain.vote.dto.request.VoteSubmitRequest;
 import com.moa.moa_server.domain.vote.dto.request.VoteUpdateRequest;
-import com.moa.moa_server.domain.vote.dto.response.VoteCreateResponse;
-import com.moa.moa_server.domain.vote.dto.response.VoteDetailResponse;
-import com.moa.moa_server.domain.vote.dto.response.VoteModerationReasonResponse;
-import com.moa.moa_server.domain.vote.dto.response.VoteUpdateResponse;
+import com.moa.moa_server.domain.vote.dto.response.*;
 import com.moa.moa_server.domain.vote.dto.response.active.ActiveVoteResponse;
 import com.moa.moa_server.domain.vote.dto.response.mine.MyVoteResponse;
 import com.moa.moa_server.domain.vote.dto.response.result.VoteResultResponse;
@@ -123,6 +120,14 @@ public class VoteController {
       @PathVariable Long voteId,
       @RequestBody VoteUpdateRequest request) {
     VoteUpdateResponse response = voteService.updateVote(userId, voteId, request);
+    return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
+  }
+
+  @Operation(summary = "투표 삭제", description = "등록 실패한 투표를 삭제합니다.")
+  @DeleteMapping("/{voteId}")
+  public ResponseEntity<ApiResponse<VoteDeleteResponse>> deleteVote(
+      @AuthenticationPrincipal Long userId, @PathVariable Long voteId) {
+    VoteDeleteResponse response = voteService.deleteVote(userId, voteId);
     return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteDeleteResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteDeleteResponse.java
@@ -1,0 +1,6 @@
+package com.moa.moa_server.domain.vote.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "투표 삭제 응답 DTO")
+public record VoteDeleteResponse(@Schema(description = "삭제된 투표 ID", example = "123") Long voteId) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/entity/Vote.java
@@ -135,6 +135,11 @@ public class Vote extends BaseTimeEntity {
     this.voteStatus = VoteStatus.PENDING; // 항상 상태 초기화
   }
 
+  /** 투표 삭제 */
+  public void softDelete() {
+    this.deletedAt = LocalDateTime.now();
+  }
+
   /** 검열 결과 반영 (상태만 변경) */
   public void updateModerationResult(VoteStatus voteStatus) {
     this.voteStatus = voteStatus;


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #204

## 🔥 작업 개요
- 투표 삭제 기능 구현

## 🛠️ 작업 상세
- 투표 삭제 API (DELETE /api/v1/votes/{voteId}) 구현
  - 본인 투표이면서 상태가 REJECTED인 경우에만 삭제 가능
  - soft delete 방식
  - 연관 데이터: 존재 가능성을 고려하여 처리
     - 댓글: 함께 soft delete
     - 투표 검열 기록, 투표 응답, 투표 결과: 투표 물리 삭제 시 hard delete 처리
  - 삭제된 투표는 목록/상세 조회에서 제외

## 🧪 테스트

* [x] Postman을 통한 API 테스트 완료
* [x] 본인 + REJECTED 상태 투표 삭제 성공 (200 OK)
* [x] 타인 투표 또는 승인된 투표 삭제 시 403 FORBIDDEN
* [x] 삭제된 투표는 목록/상세 조회 시 노출되지 않음
* [x] 연관 댓글/응답도 조회되지 않음
  
## 💬 기타 논의 사항

* 없음
