### PR TITLE
feat: 그룹 삭제 API 구현

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/group/controller/GroupController.java
+++ b/src/main/java/com/moa/moa_server/domain/group/controller/GroupController.java
@@ -4,6 +4,7 @@ import com.moa.moa_server.domain.global.dto.ApiResponse;
 import com.moa.moa_server.domain.group.dto.request.GroupCreateRequest;
 import com.moa.moa_server.domain.group.dto.request.GroupJoinRequest;
 import com.moa.moa_server.domain.group.dto.response.GroupCreateResponse;
+import com.moa.moa_server.domain.group.dto.response.GroupDeleteResponse;
 import com.moa.moa_server.domain.group.dto.response.GroupJoinResponse;
 import com.moa.moa_server.domain.group.service.GroupService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,10 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Group", description = "그룹 도메인 API")
 @RestController
@@ -38,5 +36,13 @@ public class GroupController {
       @AuthenticationPrincipal Long userId, @RequestBody GroupCreateRequest request) {
     GroupCreateResponse response = groupService.createGroup(userId, request);
     return ResponseEntity.status(201).body(new ApiResponse<>("SUCCESS", response));
+  }
+
+  @Operation(summary = "그룹 삭제")
+  @DeleteMapping("/{groupId}")
+  public ResponseEntity<ApiResponse<GroupDeleteResponse>> deleteGroup(
+      @AuthenticationPrincipal Long userId, @PathVariable Long groupId) {
+    GroupDeleteResponse response = groupService.deleteGroup(userId, groupId);
+    return ResponseEntity.status(200).body(new ApiResponse<>("SUCCESS", response));
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/group/dto/response/GroupDeleteResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/group/dto/response/GroupDeleteResponse.java
@@ -1,0 +1,7 @@
+package com.moa.moa_server.domain.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "그룹 삭제 응답 DTO")
+public record GroupDeleteResponse(
+    @Schema(description = "삭제된 그룹 ID", example = "17") Long groupId) {}

--- a/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
+++ b/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
@@ -63,15 +63,19 @@ public class Group extends BaseTimeEntity {
         .build();
   }
 
-  public boolean isPublicGroup() {
-    return this.id != null && this.id.equals(PUBLIC_GROUP_ID);
+  public void softDelete() {
+    this.deletedAt = LocalDateTime.now();
   }
 
   public void changeOwner(User newOwner) {
     this.user = newOwner;
   }
 
-  public void softDelete() {
-    this.deletedAt = LocalDateTime.now();
+  public boolean isPublicGroup() {
+    return this.id != null && this.id.equals(PUBLIC_GROUP_ID);
+  }
+
+  public boolean isOwnedBy(long userId) {
+    return this.user.getId().equals(userId);
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
@@ -4,14 +4,16 @@ import com.moa.moa_server.domain.global.exception.BaseErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum GroupErrorCode implements BaseErrorCode {
-  GROUP_NOT_FOUND(HttpStatus.NOT_FOUND),
   INVALID_CODE_FORMAT(HttpStatus.BAD_REQUEST),
+  INVALID_INPUT(HttpStatus.BAD_REQUEST),
+  CANNOT_JOIN_PUBLIC_GROUP(HttpStatus.BAD_REQUEST),
+  NOT_GROUP_OWNER(HttpStatus.FORBIDDEN),
+  GROUP_NOT_FOUND(HttpStatus.NOT_FOUND),
   INVITE_CODE_NOT_FOUND(HttpStatus.NOT_FOUND),
   ALREADY_JOINED(HttpStatus.CONFLICT),
-  CANNOT_JOIN_PUBLIC_GROUP(HttpStatus.BAD_REQUEST),
-  INVALID_INPUT(HttpStatus.BAD_REQUEST),
+  DUPLICATED_NAME(HttpStatus.CONFLICT),
   INVITE_CODE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR),
-  DUPLICATED_NAME(HttpStatus.CONFLICT);
+  ;
 
   private final HttpStatus status;
 

--- a/src/main/java/com/moa/moa_server/domain/group/service/GroupService.java
+++ b/src/main/java/com/moa/moa_server/domain/group/service/GroupService.java
@@ -4,6 +4,7 @@ import com.moa.moa_server.domain.global.util.XssUtil;
 import com.moa.moa_server.domain.group.dto.request.GroupCreateRequest;
 import com.moa.moa_server.domain.group.dto.request.GroupJoinRequest;
 import com.moa.moa_server.domain.group.dto.response.GroupCreateResponse;
+import com.moa.moa_server.domain.group.dto.response.GroupDeleteResponse;
 import com.moa.moa_server.domain.group.dto.response.GroupJoinResponse;
 import com.moa.moa_server.domain.group.entity.Group;
 import com.moa.moa_server.domain.group.entity.GroupMember;
@@ -18,8 +19,7 @@ import com.moa.moa_server.domain.user.handler.UserErrorCode;
 import com.moa.moa_server.domain.user.handler.UserException;
 import com.moa.moa_server.domain.user.repository.UserRepository;
 import com.moa.moa_server.domain.user.util.AuthUserValidator;
-import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
-import com.moa.moa_server.domain.vote.handler.VoteException;
+import com.moa.moa_server.domain.vote.service.VoteService;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -36,17 +36,13 @@ public class GroupService {
   private static final int MAX_INVITE_CODE_RETRY = 10;
 
   private final ImageService imageService;
+  private final VoteService voteService;
 
   private final GroupRepository groupRepository;
   private final UserRepository userRepository;
   private final GroupMemberRepository groupMemberRepository;
 
-  public Group getPublicGroup() {
-    return groupRepository
-        .findById(1L)
-        .orElseThrow(() -> new VoteException(VoteErrorCode.GROUP_NOT_FOUND));
-  }
-
+  /** 그룹 가입 */
   @Transactional
   public GroupJoinResponse joinGroup(Long userId, GroupJoinRequest request) {
     String inviteCode = request.inviteCode().trim().toUpperCase();
@@ -96,6 +92,7 @@ public class GroupService {
     return new GroupJoinResponse(group.getId(), group.getName(), member.getRole().name());
   }
 
+  /** 그룹 생성 */
   @Transactional
   public GroupCreateResponse createGroup(Long userId, GroupCreateRequest request) {
     // 유저 조회 및 검증
@@ -157,6 +154,7 @@ public class GroupService {
     throw new GroupException(GroupErrorCode.INVITE_CODE_GENERATION_FAILED);
   }
 
+  /** 그룹 소유권 승계 (그룹 소유자가 회원탈퇴 시 사용) */
   @Transactional
   public void reassignOrDeleteGroupsOwnedBy(User user) {
     // 사용자가 소유한 그룹 목록 조회

--- a/src/main/java/com/moa/moa_server/domain/group/util/GroupLookupHelper.java
+++ b/src/main/java/com/moa/moa_server/domain/group/util/GroupLookupHelper.java
@@ -1,0 +1,21 @@
+package com.moa.moa_server.domain.group.util;
+
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.repository.GroupRepository;
+import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
+import com.moa.moa_server.domain.vote.handler.VoteException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GroupLookupHelper {
+
+  private final GroupRepository groupRepository;
+
+  public Group getPublicGroup() {
+    return groupRepository
+        .findById(1L)
+        .orElseThrow(() -> new VoteException(VoteErrorCode.GROUP_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
+++ b/src/main/java/com/moa/moa_server/domain/user/service/UserService.java
@@ -11,6 +11,7 @@ import com.moa.moa_server.domain.group.entity.Group;
 import com.moa.moa_server.domain.group.entity.GroupMember;
 import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
 import com.moa.moa_server.domain.group.service.GroupService;
+import com.moa.moa_server.domain.group.util.GroupLookupHelper;
 import com.moa.moa_server.domain.user.dto.request.UserUpdateRequest;
 import com.moa.moa_server.domain.user.dto.response.*;
 import com.moa.moa_server.domain.user.entity.User;
@@ -40,6 +41,7 @@ public class UserService {
   private final TokenRepository tokenRepository;
   private final VoteRepository voteRepository;
 
+  private final GroupLookupHelper groupLookupHelper;
   private final GroupService groupService;
   private final AuthService authService;
 
@@ -64,7 +66,7 @@ public class UserService {
 
     // 첫 페이지인 경우 공개 그룹을 제일 앞에 추가
     if (cursor == null) {
-      Group publicGroup = groupService.getPublicGroup();
+      Group publicGroup = groupLookupHelper.getPublicGroup();
       groups.addFirst(publicGroup);
     }
 

--- a/src/main/java/com/moa/moa_server/domain/vote/repository/VoteRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/repository/VoteRepository.java
@@ -3,6 +3,7 @@ package com.moa.moa_server.domain.vote.repository;
 import com.moa.moa_server.domain.user.entity.User;
 import com.moa.moa_server.domain.vote.entity.Vote;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,6 +14,13 @@ public interface VoteRepository extends JpaRepository<Vote, Long>, VoteRepositor
   @Modifying
   @Query("UPDATE Vote v SET v.deletedAt = CURRENT_TIMESTAMP WHERE v.user = :user")
   void softDeleteAllByUser(@Param("user") User user);
+
+  @Modifying
+  @Query("UPDATE Vote v SET v.deletedAt = CURRENT_TIMESTAMP WHERE v.group.id = :groupId")
+  void softDeleteByGroupId(@Param("groupId") Long groupId);
+
+  @Query("SELECT v.id FROM Vote v WHERE v.group.id = :groupId")
+  List<Long> findAllIdsByGroupId(@Param("groupId") Long groupId);
 
   @Modifying(clearAutomatically = true)
   @Query(

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteRelatedDataCleaner.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteRelatedDataCleaner.java
@@ -1,0 +1,18 @@
+package com.moa.moa_server.domain.vote.service;
+
+import com.moa.moa_server.domain.comment.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class VoteRelatedDataCleaner {
+
+  private final CommentRepository commentRepository;
+
+  @Transactional
+  public void cleanup(Long voteId) {
+    commentRepository.softDeleteByVoteId(voteId);
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -535,7 +535,7 @@ public class VoteService {
     vote.softDelete();
 
     // 4. 관련 데이터 정리 (존재할 수 있는 경우)
-    commentRepository.softDeleteByVoteId(voteId);
+    voteRelatedDataCleaner.cleanup(voteId);
 
     return new VoteDeleteResponse(voteId);
   }
@@ -622,5 +622,16 @@ public class VoteService {
     List<Group> userGroups = groupMemberRepository.findAllActiveGroupsByUser(user);
 
     return Stream.concat(Stream.of(publicGroup), userGroups.stream()).distinct().toList();
+  }
+
+  public void deleteVoteByGroupId(Long groupId) {
+    // 1. 해당 그룹의 모든 투표 soft delete
+    voteRepository.softDeleteByGroupId(groupId);
+
+    // 2. 각 투표의 연관 데이터 정리
+    List<Long> voteIds = voteRepository.findAllIdsByGroupId(groupId);
+    for (Long voteId : voteIds) {
+      voteRelatedDataCleaner.cleanup(voteId);
+    }
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #206

## 🔥 작업 개요
- 그룹 삭제 기능 구현

## 🛠️ 작업 상세

* `DELETE /api/v1/groups/{groupId}` API 구현
  * 그룹 소유자만 삭제 가능하도록 권한 검증 추가
  * soft delete 방식
  * 삭제된 그룹은 가입 불가, 목록/상세 조회 불가
  * 그룹 생성 시 삭제된 그룹의 이름 사용 가능
* 연관 데이터 정리
  * 그룹 내 투표 전체 soft delete
  * 각 투표의 연관 데이터 정리
  * 정리 로직은 `VoteService.deleteVoteByGroupId()`에서 통합 관리

## 🧪 테스트

* [x] Postman을 통한 API 테스트 완료
* [x] 소유자에 의한 그룹 삭제 성공 (`200 OK`)
* [x] 비소유자 요청 시 `403 NOT_GROUP_OWNER`
* [x] 삭제된 그룹은 목록/상세/초대코드 접근 모두 불가
* [x] 삭제된 그룹의 투표 및 관련 데이터도 미노출

## 💬 기타 논의 사항

* 없음
