### PR TITLE
feat: 그룹 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/group/controller/GroupController.java
+++ b/src/main/java/com/moa/moa_server/domain/group/controller/GroupController.java
@@ -2,9 +2,11 @@ package com.moa.moa_server.domain.group.controller;
 
 import com.moa.moa_server.domain.global.dto.ApiResponse;
 import com.moa.moa_server.domain.group.dto.request.GroupCreateRequest;
+import com.moa.moa_server.domain.group.dto.request.GroupUpdateRequest;
 import com.moa.moa_server.domain.group.dto.response.GroupCreateResponse;
 import com.moa.moa_server.domain.group.dto.response.GroupDeleteResponse;
 import com.moa.moa_server.domain.group.dto.response.GroupInfoResponse;
+import com.moa.moa_server.domain.group.dto.response.GroupUpdateResponse;
 import com.moa.moa_server.domain.group.service.GroupService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,6 +44,16 @@ public class GroupController {
   public ResponseEntity<ApiResponse<GroupInfoResponse>> getGroupInfo(
       @AuthenticationPrincipal Long userId, @PathVariable Long groupId) {
     GroupInfoResponse response = groupService.getGroupInfo(userId, groupId);
+    return ResponseEntity.status(200).body(new ApiResponse<>("SUCCESS", response));
+  }
+
+  @Operation(summary = "그룹 정보 수정")
+  @PatchMapping("/{groupId}")
+  public ResponseEntity<ApiResponse<GroupUpdateResponse>> updateGroup(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long groupId,
+      @RequestBody GroupUpdateRequest request) {
+    GroupUpdateResponse response = groupService.updateGroup(userId, groupId, request);
     return ResponseEntity.status(200).body(new ApiResponse<>("SUCCESS", response));
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/group/dto/request/GroupUpdateRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/group/dto/request/GroupUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.moa.moa_server.domain.group.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "그룹 수정 요청 DTO")
+public record GroupUpdateRequest(
+    @Schema(description = "변경할 그룹 이름", example = "KTB") String name,
+    @Schema(description = "변경할 그룹 소개", example = "카카오 부트캠프 야자타임 전용 그룹입니다.") String description,
+    @Schema(description = "변경할 그룹 이미지 URL", example = "https://s3.amazonaws.com/group-img/ktb.jpg")
+        String imageUrl,
+    @Schema(description = "첨부 이미지 이름", example = "카테부단체사진.jpeg") String imageName,
+    @Schema(description = "초대코드 재생성 여부", example = "false") boolean changeInviteCode) {}

--- a/src/main/java/com/moa/moa_server/domain/group/dto/response/GroupUpdateResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/group/dto/response/GroupUpdateResponse.java
@@ -1,0 +1,27 @@
+package com.moa.moa_server.domain.group.dto.response;
+
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.entity.GroupMember;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "그룹 수정 응답 DTO")
+public record GroupUpdateResponse(
+    @Schema(description = "그룹 ID", example = "3") Long groupId,
+    @Schema(description = "그룹 이름", example = "KTB") String name,
+    @Schema(description = "그룹 소개", example = "카카오 부트캠프 야자타임 전용 그룹입니다.") String description,
+    @Schema(description = "그룹 이미지 URL", example = "https://s3.amazonaws.com/group-img/ktb.jpg")
+        String imageUrl,
+    @Schema(description = "그룹 이미지 이름", example = "카테부단체사진.jpeg") String imageName,
+    @Schema(description = "초대코드", example = "E78XC1") String changeInviteCode,
+    @Schema(description = "사용자의 그룹 역할", example = "MEMBER") String role) {
+  public static GroupUpdateResponse of(Group group, GroupMember.Role role) {
+    return new GroupUpdateResponse(
+        group.getId(),
+        group.getName(),
+        group.getDescription(),
+        group.getImageUrl(),
+        group.getImageName(),
+        group.getInviteCode(),
+        role.name());
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
+++ b/src/main/java/com/moa/moa_server/domain/group/entity/Group.java
@@ -67,6 +67,17 @@ public class Group extends BaseTimeEntity {
     this.deletedAt = LocalDateTime.now();
   }
 
+  public void updateInfo(String name, String description, String imageUrl, String imageName) {
+    this.name = name;
+    this.description = description;
+    this.imageUrl = imageUrl;
+    this.imageName = imageName;
+  }
+
+  public void updateInviteCode(String newCode) {
+    this.inviteCode = newCode;
+  }
+
   public void changeOwner(User newOwner) {
     this.user = newOwner;
   }

--- a/src/main/java/com/moa/moa_server/domain/group/entity/GroupMember.java
+++ b/src/main/java/com/moa/moa_server/domain/group/entity/GroupMember.java
@@ -87,4 +87,8 @@ public class GroupMember {
   public void changeToOwner() {
     this.role = Role.OWNER;
   }
+
+  public boolean isOwnerOrManager() {
+    return this.role == Role.OWNER || this.role == Role.MANAGER;
+  }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -496,11 +496,16 @@ public class VoteService {
 
     // 4. 이미지 URL/이름 처리
     ImageProcessResult imageResult =
-        imageService.processImageOnVoteUpdate(
-            vote.getImageUrl(), request.imageUrl(), vote.getImageName(), request.imageName());
+        imageService.processImageOnUpdate(
+            "vote",
+            vote.getImageUrl(),
+            request.imageUrl(),
+            vote.getImageName(),
+            request.imageName());
 
     // 5. content, url, closedAt 업데이트 및 저장
-    vote.updateForEdit(request.content(), imageResult.imageUrl(), imageResult.imageName(), utcTime);
+    String sanitizedContent = XssUtil.sanitize(request.content());
+    vote.updateForEdit(sanitizedContent, imageResult.imageUrl(), imageResult.imageName(), utcTime);
     voteRepository.save(vote);
 
     // 6. AI 서버로 검열 요청 (prod 환경에서만)

--- a/src/test/java/com/moa/moa_server/unit/vote/service/VoteUpdateTest.java
+++ b/src/test/java/com/moa/moa_server/unit/vote/service/VoteUpdateTest.java
@@ -50,7 +50,7 @@ public class VoteUpdateTest {
       when(vote.getId()).thenReturn(voteId);
       when(vote.getUser()).thenReturn(user);
       when(vote.getVoteStatus()).thenReturn(Vote.VoteStatus.REJECTED);
-      when(imageService.processImageOnVoteUpdate(any(), any(), any(), any()))
+      when(imageService.processImageOnUpdate(eq("vote"), any(), any(), any(), any()))
           .thenReturn(new ImageProcessResult("vote/abc.jpg", "파일이름.jpeg"));
 
       // when
@@ -90,7 +90,7 @@ public class VoteUpdateTest {
       when(vote.getVoteStatus()).thenReturn(Vote.VoteStatus.REJECTED);
 
       // 기존 이미지와 동일한 경우 그대로 반환
-      when(imageService.processImageOnVoteUpdate(any(), any(), any(), any()))
+      when(imageService.processImageOnUpdate(eq("vote"), any(), any(), any(), any()))
           .thenReturn(new ImageProcessResult(oldImageUrl, oldImageName));
 
       // when
@@ -127,7 +127,7 @@ public class VoteUpdateTest {
       when(vote.getVoteStatus()).thenReturn(Vote.VoteStatus.REJECTED);
 
       // 빈 이미지면 기존 이미지 삭제 & 빈 문자열 반환
-      when(imageService.processImageOnVoteUpdate(any(), any(), any(), any()))
+      when(imageService.processImageOnUpdate(eq("vote"), any(), any(), any(), any()))
           .thenReturn(new ImageProcessResult("", ""));
 
       // when
@@ -137,7 +137,7 @@ public class VoteUpdateTest {
       assertThat(resp.voteId()).isEqualTo(voteId);
       verify(vote).updateForEdit(eq("본문"), eq(""), eq(""), any(LocalDateTime.class));
       verify(voteRepository).save(any(Vote.class));
-      verify(imageService).processImageOnVoteUpdate(any(), any(), any(), any());
+      verify(imageService).processImageOnUpdate(eq("vote"), any(), any(), any(), any());
     }
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #212

### 🔥 작업 개요

* 그룹 정보(이름, 소개, 이미지, 초대코드) 수정 기능 구현
* 그룹 소유자 또는 관리자만 수정 가능

### 🛠️ 작업 상세

* `PATCH /api/v1/groups/{groupId}` API 추가
  * 권한 검증: 그룹 멤버면서 `OWNER` 또는 `MANAGER`만 가능
  * 그룹 이름/소개 입력값 유효성 검사 및 XSS 필터링 적용
  * 그룹 이름 중복 시 `409 Conflict` 반환
  * 이미지 URL 변경 시 S3 이미지 처리 로직 적용 (vote/group 구분)
  * `changeInviteCode=true` 시 초대코드 새로 생성

### 🧪 테스트

* 포스트맨으로 정상 동작 테스트 완료
* 이미지 이동 확인
* 권한 없음 (FORBIDDEN) 테스트 완료

### 💬 기타 논의 사항
* 없음
