### PR TITLE
feat: 그룹 멤버 내보내기 API 구현

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/group/controller/GroupMemberController.java
+++ b/src/main/java/com/moa/moa_server/domain/group/controller/GroupMemberController.java
@@ -3,6 +3,7 @@ package com.moa.moa_server.domain.group.controller;
 import com.moa.moa_server.domain.global.dto.ApiResponse;
 import com.moa.moa_server.domain.group.dto.request.ChangeRoleRequest;
 import com.moa.moa_server.domain.group.dto.response.ChangeRoleResponse;
+import com.moa.moa_server.domain.group.dto.response.MemberDeleteResponse;
 import com.moa.moa_server.domain.group.dto.response.MemberListResponse;
 import com.moa.moa_server.domain.group.service.GroupMemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,6 +39,16 @@ public class GroupMemberController {
       @RequestBody @Valid ChangeRoleRequest request) {
     ChangeRoleResponse response =
         groupMemberService.changeRole(userId, groupId, targetUserId, request.role());
+    return ResponseEntity.status(200).body(new ApiResponse<>("SUCCESS", response));
+  }
+
+  @Operation(summary = "그룹 멤버 내보내기", description = "소유자가 그룹 멤버를 그룹에서 내보낼 수 있습니다.")
+  @DeleteMapping("/{groupId}/members/{targetUserId}")
+  public ResponseEntity<ApiResponse<MemberDeleteResponse>> deleteMember(
+      @AuthenticationPrincipal Long userId,
+      @PathVariable Long groupId,
+      @PathVariable Long targetUserId) {
+    MemberDeleteResponse response = groupMemberService.deleteMember(userId, groupId, targetUserId);
     return ResponseEntity.status(200).body(new ApiResponse<>("SUCCESS", response));
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/group/dto/response/MemberDeleteResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/group/dto/response/MemberDeleteResponse.java
@@ -1,0 +1,7 @@
+package com.moa.moa_server.domain.group.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "그룹 멤버 내보내기 응답 DTO")
+public record MemberDeleteResponse(
+    @Schema(description = "추방된 사용자 ID", example = "5") Long userId) {}

--- a/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/group/handler/GroupErrorCode.java
@@ -16,6 +16,7 @@ public enum GroupErrorCode implements BaseErrorCode {
   MEMBERSHIP_NOT_FOUND(HttpStatus.NOT_FOUND),
   ALREADY_JOINED(HttpStatus.CONFLICT),
   DUPLICATED_NAME(HttpStatus.CONFLICT),
+  CANNOT_KICK_SELF(HttpStatus.CONFLICT),
   INVITE_CODE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR),
   ;
 


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #218

## 🔥 작업 개요
- 그룹 멤버 내보내기 기능 구현

## 🛠️ 작업 상세
- 그룹 소유자가 그룹 멤버를 추방할 수 있는 API (`DELETE /api/v1/groups/{groupId}/members/{userId}`) 구현

## 🧪 테스트

* [x] 포스트맨으로 테스트 완료
* [x] 정상 추방 (소유자 → 매니저 or 멤버)
* [x] 자기 자신 추방 시도 → `409 CONFLICT`
* [x] 소유자 외 추방 시도 → `403 FORBIDDEN`
* [x] 존재하지 않는 유저/그룹/멤버십 → `404 NOT FOUND`
  
## 💬 기타 논의 사항

* 없음

