### PR TITLE
feat: 투표 내용 조회 시 그룹 이름도 함께 전달

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteDetailResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/VoteDetailResponse.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 public record VoteDetailResponse(
     @Schema(description = "투표 ID", example = "123") Long voteId,
     @Schema(description = "투표가 속한 그룹 ID", example = "1") Long groupId,
+    @Schema(description = "투표가 속한 그룹 이름", example = "공개") String groupName,
     @Schema(description = "투표 등록자 닉네임 (익명 투표인 경우, '익명'으로 전달)", example = "nickname")
         String authorNickname,
     @Schema(description = "투표 본문 내용", example = "에어컨 추우신 분?") String content,

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -226,6 +226,7 @@ public class VoteService {
     return new VoteDetailResponse(
         vote.getId(),
         vote.getGroup().getId(),
+        vote.getGroup().getName(),
         vote.isAnonymous() ? "익명" : vote.getUser().getNickname(),
         vote.getContent(),
         vote.getImageUrl(),


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #226

## 🔥 작업 개요
- 투표 내용 조회 시 그룹 이름도 함께 전달
- 작업 이유: FE측 화면설계 요구사항

## 🧪 테스트

* [x] Postman 정상동작 테스트 
  
## 💬 기타 논의 사항

* 없ㅇ ㅁ
