### PR TITLE
feat: 실시간 알림 전송을 위한 SSE 기능 구현

### DIFF
--- a/src/main/java/com/moa/moa_server/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/moa/moa_server/config/security/CustomAuthenticationEntryPoint.java
@@ -27,7 +27,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     response.setContentType("application/json");
     response.setCharacterEncoding("UTF-8");
 
-    ApiResponse apiResponse = new ApiResponse("INVALID_TOKEN", null);
+    ApiResponse apiResponse = new ApiResponse(authException.getMessage(), null);
     response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
   }
 }

--- a/src/main/java/com/moa/moa_server/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moa/moa_server/config/security/JwtAuthenticationFilter.java
@@ -21,6 +21,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtTokenService jwtTokenService; // 토큰 유효성 검증 및 userId 추출
+  private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 
   @Override
   protected void doFilterInternal(
@@ -47,8 +48,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
       filterChain.doFilter(request, response);
     } catch (AuthException e) {
-      // AuthException을 AuthenticationException으로 감싸서 Spring Security로 위임
-      throw new AuthenticationCredentialsNotFoundException(e.getCode(), e);
+      // AuthException을 AuthenticationException으로 감싸서 EntryPoint 호출
+      authenticationEntryPoint.commence(
+          request, response, new AuthenticationCredentialsNotFoundException(e.getCode(), e));
     }
   }
 

--- a/src/main/java/com/moa/moa_server/domain/global/util/JsonUtil.java
+++ b/src/main/java/com/moa/moa_server/domain/global/util/JsonUtil.java
@@ -1,0 +1,16 @@
+package com.moa.moa_server.domain.global.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JsonUtil {
+  private static ObjectMapper objectMapper = new ObjectMapper();
+
+  public static String toJson(Object obj) {
+    try {
+      return objectMapper.writeValueAsString(obj);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("JSON 직렬화 실패", e);
+    }
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/notification/application/service/NotificationSseService.java
+++ b/src/main/java/com/moa/moa_server/domain/notification/application/service/NotificationSseService.java
@@ -1,0 +1,78 @@
+package com.moa.moa_server.domain.notification.application.service;
+
+import com.moa.moa_server.domain.notification.application.sse.NotificationSseSender;
+import com.moa.moa_server.domain.notification.config.SseProperties;
+import com.moa.moa_server.domain.notification.repository.NotificationEmitterRepository;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.handler.UserErrorCode;
+import com.moa.moa_server.domain.user.handler.UserException;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.user.util.AuthUserValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/** SSE 구독 요청을 처리하는 서비스 클래스. */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationSseService {
+
+  private final SseProperties sseProperties;
+  private final NotificationEmitterRepository emitterRepository;
+  private final UserRepository userRepository;
+  private final NotificationSseSender notificationSseSender;
+
+  /**
+   * 사용자 SSE 구독 처리.
+   *
+   * <p>SseEmitter를 등록하고, 연결 직후 dummy 전송과 유실 이벤트 복구를 수행한다.
+   */
+  public SseEmitter subscribe(Long userId, String lastEventId) {
+    validateUser(userId);
+
+    // emitter 등록
+    SseEmitter emitter = registerEmitter(userId);
+
+    // 최초 연결 시 더미 이벤트 전송
+    notificationSseSender.sendDummyEvent(emitter);
+
+    // 마지막 이벤트 ID로 유실된 이벤트 전송
+    if (lastEventId != null) {
+      notificationSseSender.sendLostEvents(userId, lastEventId, emitter);
+    }
+
+    return emitter;
+  }
+
+  private SseEmitter registerEmitter(Long userId) {
+    SseEmitter emitter = new SseEmitter(sseProperties.getTimeout());
+    String emitterId = makeEmitterId(userId);
+
+    emitterRepository.save(emitterId, emitter);
+
+    // 연결 끊김/에러 시 emitter 정리
+    emitter.onCompletion(() -> emitterRepository.deleteById(emitterId)); // 클라이언트 정상 종료
+    emitter.onTimeout(
+        () -> {
+          emitter.complete(); // AsyncRequestTimeoutException 예외 로그 남지 않도록 명시적 종료
+          emitterRepository.deleteById(emitterId);
+        }); // 서버 타임아웃
+    emitter.onError((e) -> emitterRepository.deleteById(emitterId)); // 전송 중 예외 (IOException)
+
+    return emitter;
+  }
+
+  private String makeEmitterId(Long userId) {
+    return userId + "_" + System.currentTimeMillis();
+  }
+
+  private void validateUser(Long userId) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    AuthUserValidator.validateActive(user);
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/notification/application/sse/NotificationSseBroadcaster.java
+++ b/src/main/java/com/moa/moa_server/domain/notification/application/sse/NotificationSseBroadcaster.java
@@ -1,0 +1,39 @@
+package com.moa.moa_server.domain.notification.application.sse;
+
+import static com.moa.moa_server.domain.global.util.JsonUtil.toJson;
+
+import com.moa.moa_server.domain.notification.dto.NotificationItem;
+import com.moa.moa_server.domain.notification.entity.Notification;
+import com.moa.moa_server.domain.notification.repository.NotificationEmitterRepository;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/** 알림(Notification)을 특정 사용자에게 연결된 모든 SSE emitter에 브로드캐스팅하는 컴포넌트. */
+@Component
+@RequiredArgsConstructor
+public class NotificationSseBroadcaster {
+
+  private final NotificationEmitterRepository emitterRepository;
+
+  public void send(Notification notification) {
+    String payload = toJson(NotificationItem.from(notification));
+    SseEmitter.SseEventBuilder event =
+        SseEmitter.event()
+            .id(String.valueOf(notification.getId()))
+            .name("notification")
+            .data(payload);
+
+    emitterRepository
+        .findAllByUserId(notification.getUser().getId())
+        .forEach(
+            (id, emitter) -> {
+              try {
+                emitter.send(event);
+              } catch (IOException e) {
+                emitterRepository.deleteById(id); // 연결이 끊긴 emitter는 삭제
+              }
+            });
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/notification/application/sse/NotificationSseCleaner.java
+++ b/src/main/java/com/moa/moa_server/domain/notification/application/sse/NotificationSseCleaner.java
@@ -1,0 +1,48 @@
+package com.moa.moa_server.domain.notification.application.sse;
+
+import com.moa.moa_server.domain.notification.config.SseProperties;
+import com.moa.moa_server.domain.notification.repository.NotificationEmitterRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** 주기적으로 오래된 SSE Emitter를 정리하는 컴포넌트. */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationSseCleaner {
+
+  private final NotificationEmitterRepository emitterRepository;
+  private final SseProperties sseProperties;
+
+  @Scheduled(fixedRateString = "#{@sseProperties.staleCleanInterval}")
+  public void cleanUpStaleEmitters() {
+    long now = System.currentTimeMillis();
+    long threshold = sseProperties.getStaleThreshold();
+
+    int before = emitterRepository.findAllEmitters().size();
+
+    emitterRepository
+        .findAllEmitters()
+        .entrySet()
+        .removeIf(
+            entry -> {
+              String key = entry.getKey(); // user_timestamp
+              String[] parts = key.split("_");
+              if (parts.length != 2) return true;
+
+              try {
+                long createdAt = Long.parseLong(parts[1]);
+                return (now - createdAt) > threshold;
+              } catch (NumberFormatException e) {
+                return true; // 잘못된 형식의 키도 정리
+              }
+            });
+
+    int after = emitterRepository.findAllEmitters().size();
+    if (before != after) {
+      log.info("[NotificationSseCleaner#cleanUpStaleEmitters] 만료된 emitter 정리: {}개", before - after);
+    }
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/notification/application/sse/NotificationSseConnectionHelper.java
+++ b/src/main/java/com/moa/moa_server/domain/notification/application/sse/NotificationSseConnectionHelper.java
@@ -1,0 +1,57 @@
+package com.moa.moa_server.domain.notification.application.sse;
+
+import static com.moa.moa_server.domain.global.util.JsonUtil.toJson;
+
+import com.moa.moa_server.domain.notification.dto.NotificationItem;
+import com.moa.moa_server.domain.notification.entity.Notification;
+import com.moa.moa_server.domain.notification.repository.NotificationEmitterRepository;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/** SSE 연결 후 초기 이벤트 전송(dummy, 유실 이벤트)을 담당하는 헬퍼 클래스. */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationSseConnectionHelper {
+
+  private final NotificationEmitterRepository emitterRepository;
+
+  public void sendDummyEvent(SseEmitter emitter) {
+    try {
+      SseEmitter.SseEventBuilder event =
+          SseEmitter.event()
+              .name("dummy")
+              .data("ping")
+              .reconnectTime(10000); // 클라이언트 재연결 간격 설정 (최초 1회)
+      emitter.send(event);
+    } catch (IOException e) {
+      log.warn("초기 SSE 이벤트 전송 실패. emitter는 유지", e); // 초기 전송 실패는 일시적일 수 있으므로 무시하고 연결 유지
+    }
+  }
+
+  public void sendLostEvents(Long userId, String lastEventId, SseEmitter emitter) {
+    // lastEventId 이후 이벤트 찾아 전송
+    List<Notification> lostEvents = emitterRepository.findCachedEventsAfter(userId, lastEventId);
+
+    for (Notification notification : lostEvents) {
+      try {
+        String payload = toJson(NotificationItem.from(notification));
+        SseEmitter.SseEventBuilder event =
+            SseEmitter.event()
+                .id(String.valueOf(notification.getId()))
+                .name("notification")
+                .data(payload);
+        emitter.send(event);
+      } catch (IOException e) {
+        log.warn("초기 SSE 이벤트 전송 실패. emitter는 유지", e); // 초기 전송 실패는 일시적일 수 있으므로 무시하고 연결 유지
+        // 유실된 이벤트는 재시도하지 않음
+        // - 이유: DB에 저장되어 목록 조회 가능, 다음 알림으로 빨간점 표시 가능, 타임아웃(5분) 이후 재연결 시 재전송됨
+        // - 필요 시 큐 + 재시도 스케줄러 구조 도입 (구현 복잡도 대비 실효성 낮아 현재는 미도입)
+      }
+    }
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/notification/application/sse/NotificationSseHealthChecker.java
+++ b/src/main/java/com/moa/moa_server/domain/notification/application/sse/NotificationSseHealthChecker.java
@@ -1,0 +1,31 @@
+package com.moa.moa_server.domain.notification.application.sse;
+
+import com.moa.moa_server.domain.notification.repository.NotificationEmitterRepository;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/** 주기적으로 서버에 존재하는 모든 SseEmitter에 ping 이벤트를 전송하여 연결 상태를 점검하는 컴포넌트. */
+@Component
+@RequiredArgsConstructor
+public class NotificationSseHealthChecker {
+
+  private final NotificationEmitterRepository emitterRepository;
+
+  @Scheduled(fixedRateString = "#{@sseProperties.pingInterval}")
+  public void sendPing() {
+    emitterRepository
+        .findAllEmitters()
+        .forEach(
+            (id, emitter) -> {
+              try {
+                SseEmitter.SseEventBuilder event = SseEmitter.event().name("dummy").data("ping");
+                emitter.send(event);
+              } catch (IOException e) {
+                emitterRepository.deleteById(id);
+              }
+            });
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/notification/application/sse/NotificationSseSender.java
+++ b/src/main/java/com/moa/moa_server/domain/notification/application/sse/NotificationSseSender.java
@@ -1,0 +1,48 @@
+package com.moa.moa_server.domain.notification.application.sse;
+
+import com.moa.moa_server.domain.notification.entity.Notification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * 알림 SSE 전송을 위한 Facade 클래스.
+ *
+ * <p>내부적으로 Broadcaster와 ConnectionHelper를 위임해 실제 전송 수행.
+ */
+@Component
+@RequiredArgsConstructor
+public class NotificationSseSender {
+
+  private final NotificationSseBroadcaster broadcaster;
+  private final NotificationSseConnectionHelper connectionHelper;
+
+  /**
+   * 실제 알림을 사용자에게 SSE로 전송.
+   *
+   * @param notification 전송할 알림 객체
+   */
+  public void send(Notification notification) {
+    broadcaster.send(notification);
+  }
+
+  /**
+   * SSE 연결 직후, 연결 유지 목적으로 더미 이벤트 전송.
+   *
+   * @param emitter 연결된 SseEmitter
+   */
+  public void sendDummyEvent(SseEmitter emitter) {
+    connectionHelper.sendDummyEvent(emitter);
+  }
+
+  /**
+   * 클라이언트가 놓친 이벤트들 재전송. (Last-Event-ID 기반)
+   *
+   * @param userId 알림 수신 대상 사용자 ID
+   * @param lastEventId 마지막으로 수신된 이벤트 ID
+   * @param emitter 연결된 SseEmitter
+   */
+  public void sendLostEvents(Long userId, String lastEventId, SseEmitter emitter) {
+    connectionHelper.sendLostEvents(userId, lastEventId, emitter);
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/notification/config/SseProperties.java
+++ b/src/main/java/com/moa/moa_server/domain/notification/config/SseProperties.java
@@ -1,0 +1,31 @@
+package com.moa.moa_server.domain.notification.config;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+@ConfigurationProperties(prefix = "sse")
+public class SseProperties {
+  private long timeout;
+  private long pingInterval;
+  private long staleCleanInterval;
+  private long staleThreshold;
+
+  public void setTimeout(long timeout) {
+    this.timeout = timeout;
+  }
+
+  public void setPingInterval(long pingInterval) {
+    this.pingInterval = pingInterval;
+  }
+
+  public void setStaleCleanInterval(long staleCleanInterval) {
+    this.staleCleanInterval = staleCleanInterval;
+  }
+
+  public void setStaleThreshold(long staleThreshold) {
+    this.staleThreshold = staleThreshold;
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/moa/moa_server/domain/notification/controller/NotificationController.java
@@ -1,15 +1,20 @@
 package com.moa.moa_server.domain.notification.controller;
 
 import com.moa.moa_server.domain.global.dto.ApiResponse;
+import com.moa.moa_server.domain.global.security.SecurityContextUtil;
 import com.moa.moa_server.domain.notification.application.service.NotificationService;
+import com.moa.moa_server.domain.notification.application.service.NotificationSseService;
 import com.moa.moa_server.domain.notification.dto.NotificationListResponse;
 import com.moa.moa_server.domain.notification.dto.NotificationReadResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Tag(name = "Notification", description = "알림 도메인 API")
 @RestController
@@ -18,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class NotificationController {
 
   private final NotificationService notificationService;
+  private final NotificationSseService notificationSseService;
 
   @Operation(summary = "알림 목록 조회", description = "사용자의 최신 알림 목록을 조회합니다.")
   @GetMapping
@@ -36,5 +42,16 @@ public class NotificationController {
     NotificationReadResponse response =
         notificationService.readNotification(userId, notificationId);
     return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
+  }
+
+  @Operation(summary = "알림 SSE", description = "알림 SSE 커넥션을 열고, SseEmitter를 반환합니다.")
+  @GetMapping("/subscribe")
+  public SseEmitter subscribe(
+      @AuthenticationPrincipal Long userId,
+      @RequestHeader(value = "Last-Event-ID", required = false) String lastEventId,
+      HttpServletRequest httpServletRequest,
+      HttpServletResponse httpServletResponse) {
+    SecurityContextUtil.propagateSecurityContextToRequest(httpServletRequest, httpServletResponse);
+    return notificationSseService.subscribe(userId, lastEventId);
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/notification/repository/NotificationEmitterRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/notification/repository/NotificationEmitterRepository.java
@@ -1,0 +1,44 @@
+package com.moa.moa_server.domain.notification.repository;
+
+import com.moa.moa_server.domain.notification.entity.Notification;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationEmitterRepository {
+
+  private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+  private final NotificationRepository notificationRepository;
+
+  public void save(String id, SseEmitter emitter) {
+    emitters.put(id, emitter);
+  }
+
+  public void deleteById(String id) {
+    emitters.remove(id);
+  }
+
+  public Map<String, SseEmitter> findAllEmitters() {
+    return emitters;
+  }
+
+  public Map<String, SseEmitter> findAllByUserId(Long userId) {
+    return emitters.entrySet().stream()
+        .filter(e -> e.getKey().startsWith(userId + "_"))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Transactional(readOnly = true)
+  public List<Notification> findCachedEventsAfter(Long userId, String lastEventId) {
+    Long lastId = Long.parseLong(lastEventId);
+    return notificationRepository.findByUserIdAndIdGreaterThanOrderById(userId, lastId);
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/notification/repository/NotificationRepository.java
@@ -1,7 +1,11 @@
 package com.moa.moa_server.domain.notification.repository;
 
 import com.moa.moa_server.domain.notification.entity.Notification;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository
-    extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {}
+    extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
+
+  List<Notification> findByUserIdAndIdGreaterThanOrderById(Long userId, Long id);
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -49,3 +49,9 @@ logging:
   level:
     root: INFO
     org.springframework.security: DEBUG
+
+sse:
+  timeout: 300000
+  ping-interval: 30000
+  stale-clean-interval: 1800000
+  stale-threshold: 600000

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -56,3 +56,9 @@ logging:
 #    org.hibernate.type.descriptor.sql: trace
     com.moa.moa_server.domain.vote.service.v3: DEBUG
     com.moa.moa_server.domain.comment: DEBUG
+
+sse:
+  timeout: 30000
+  ping-interval: 5000
+  stale-clean-interval: 10000
+  stale-threshold: 60000

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -55,3 +55,9 @@ logging:
   level:
     root: INFO
     org.springframework.web: WARN
+
+sse:
+  timeout: 300000
+  ping-interval: 30000
+  stale-clean-interval: 1800000
+  stale-threshold: 600000

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -56,3 +56,10 @@ logging:
     org.springframework.web.filter: DEBUG
     #    org.hibernate.type.descriptor.sql: trace
     com.moa.moa_server.domain.vote.service.v3: DEBUG
+
+sse:
+  timeout: 30000
+  ping-interval: 5000
+  stale-clean-interval: 1000
+  stale-threshold: 30000
+


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #234

## 🔥 작업 개요
- 실시간 알림 이벤트 전송을 위한 SSE(Server-Sent Events) 기능 도입

## 🛠️ 작업 상세
### 1. 클라이언트 연결
- 알림 SSE 연결를 위한 API 추가 (`GET /api/v1/notifications/subscribe`)

### 2. 이벤트 전송 흐름
   1. SSE 연결 수립
   2. 최초 연결 직후 더미 이벤트 전송 (클라이언트 측 타임아웃 방지 및 연결 확인)
   3. `Last-Event-ID` 기반 누락된 알림 재전송
   4. 새 알림 발생 시 해당 사용자에게 실시간 전송
   5. 주기적인 더미 이벤트 전송으로 연결 유지 

```
NotificationSseService (SSE 구독 연결 처리)
  └─> NotificationSseSender (알림 SSE 전송의 Facade 역할)
        └─> NotificationConnectionHelper
              ├─> lastEventId 기반 누락 알림 전송
              └─> 연결 직후 더미(ping) 이벤트 전송
```
```
NotificationEventPublisher (알림 도메인 이벤트 발행)
  └─> NotificationEventHandler (비동기 알림 전송 트리거)
        └─> NotificationSseSender (알림 SSE 전송의 Facade 역할)
              └─> NotificationBroadcaster
                    └─> emitterRepository에 등록된 emitter에 실시간 알림 전송
```

### 3. 알림 전송 구조 (Facade 패턴)
- `NotificationSseSender`가 전송의 단일 진입점 역할을 담당
- 내부 구성:
    - `NotificationBroadcaster`: 여러 emitter에 알림 전송
    - `NotificationConnectionHelper`: 연결 직후 더미 및 누락 알림 전송
- 각 컴포넌트의 책임을 분리하여 확장성, 테스트 용이성 확보

### 4. 연결 안정성 보장
   - `NotificationSseHealthChecker`: 주기적 ping 전송으로 연결 유지 및 클라이언트 연결 상태 확인
   - 클라이언트 연결 종료 및 타임아웃 예외 감지 (`AsyncRequestNotUsableException`)
   - 전역 예외 핸들러에서 해당 예외 무시 및 `text/event-stream` MIME 타입 분기 처리

### 5. 메모리 관리 (Emitter 정리)
   - `NotificationSseCleaner`: 30분 주기로 응답 없는 emitter를 정리하여 메모리 누수 방지
   - 생성된지 10분이 지난 emitter 제거
   - 네트워크 예외, 콜백 누락 등 비정상 상태 대비 위함

### 6. 환경별 property 설정
| profile      | timeout | pingInterval | staleCleanInterval | staleThreshold |
|--------------|---------|--------------|------------------|----------------|
| dev / prod   | 5분     | 30초         | 30분             | 10분           |
| local        | 30초    | 5초          | 10초             | 1분            |
| test         | 30초    | 5초          | 1초              | 10초           |
- 값 설정 근거
   - `timeout` (연결 유지 시간, 5분): 연결 시간이 너무 길면 서버의 제어권이 약해지고 stale emitter가 쌓일 수 있음. GA4 기반 평균 사용자 체류 시간이 약 6분으로 측정되어, 그보다 짧은 5분으로 설정하여 자원 관리와 사용자 경험의 균형을 맞춤
   - `pingInterval` (헬스 체크 주기, 30초): 초기에는 30초 설정하여 연결 유지가 문제 없는지 확인하고, 검증되면 유지할 예정 → 배포 후 정상적으로 연결 유지 되는 것 확인하여 유지합니다.
   - `staleCleanInterval` (정리 주기, 기본: 30분): 자원 사용 부담을 줄이기 위해 간격을 넉넉히 설정. 정리되는 emitter 개수를 로그로 남기고 리소스 사용량을 함께 모니터링하여 조정 예정
   - `staleThreshold` (정리 기준 시간, 10분): timeout이 5분이므로 10분 이상 지난 emitter는 유실된 것으로 판단

### 7. 모니터링
   - 활성 연결 수: 스케줄러를 통해 1분마다 로그 출력
   - 연결 종료/타임아웃 예외: DEBUG 레벨로 로그 출력
   - 전송 성공/실패 수, 전송 속도: 향후 로깅 또는 메트릭 시스템(Prometheus, Micrometer)과 연동하여 모니터링 예정
   - 정리된 stale emitter 수: 스케줄러를 통해 로그 출력


## 🧪 테스트

* Postman 및 로컬 환경에서 테스트 완료 (개발이 빨리 완료되어야 하여 테스트코드는 별도 작성 예정)
* [x] SSE 연결 유지 테스트: 연결 성공 - 최초 더미 이벤트 수신 - 연결 유지 - 주기적 ping 수신
* [x] 알림 발생 시 실시간 수신 확인
* [x] `Last-Event-ID` 기반 누락 알림 수신 확인
* [x] SSE 연결 중 액세스 토큰 만료 시 정상 응답 확인
* [x] 클라이언트 측 연결 끊김 시 정상 연결 종료 확인 (포스트맨 종료하는 방식으로 확인)
  
## 💬 기타 논의 사항

* 추후 메시지 브로커 도입 예정
