### PR TITLE
fix: 투표 목록 조회 응답에 댓글 수 포함

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.moa.moa_server.domain.comment.repository;
 
 import com.moa.moa_server.domain.comment.entity.Comment;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +16,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
   @Modifying
   @Query("UPDATE Comment c SET c.deletedAt = CURRENT_TIMESTAMP WHERE c.vote.id = :voteId")
   void softDeleteByVoteId(@Param("voteId") Long voteId);
+
+  @Query("SELECT c.vote.id, COUNT(c) FROM Comment c WHERE c.vote.id IN :voteIds GROUP BY c.vote.id")
+  List<Object[]> countCommentsByVoteIds(@Param("voteIds") List<Long> voteIds);
 }

--- a/src/main/java/com/moa/moa_server/domain/comment/service/CommentCountService.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/service/CommentCountService.java
@@ -1,0 +1,21 @@
+package com.moa.moa_server.domain.comment.service;
+
+import com.moa.moa_server.domain.comment.repository.CommentRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentCountService {
+
+  private final CommentRepository commentRepository;
+
+  public Map<Long, Integer> getCommentCountsByVoteIds(List<Long> voteIds) {
+    List<Object[]> rawCounts = commentRepository.countCommentsByVoteIds(voteIds);
+    return rawCounts.stream()
+        .collect(Collectors.toMap(row -> (Long) row[0], row -> ((Long) row[1]).intValue()));
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/group/dto/group_vote/GroupVoteItem.java
+++ b/src/main/java/com/moa/moa_server/domain/group/dto/group_vote/GroupVoteItem.java
@@ -11,4 +11,5 @@ public record GroupVoteItem(
     @Schema(description = "투표 본문 내용", example = "야식 메뉴 추천해주세요!") String content,
     @Schema(description = "투표 시작 시간", example = "2025-04-22T20:00:00") LocalDateTime createdAt,
     @Schema(description = "투표 종료 시간", example = "2025-04-23T20:00:00") LocalDateTime closedAt,
-    @Schema(description = "항목별 결과 리스트") List<VoteOptionResult> results) {}
+    @Schema(description = "항목별 결과 리스트") List<VoteOptionResult> results,
+    @Schema(description = "댓글 수", example = "10") int commentsCount) {}

--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
@@ -10,6 +10,7 @@ import com.moa.moa_server.domain.vote.dto.response.active.ActiveVoteResponse;
 import com.moa.moa_server.domain.vote.dto.response.mine.MyVoteResponse;
 import com.moa.moa_server.domain.vote.dto.response.result.VoteResultResponse;
 import com.moa.moa_server.domain.vote.dto.response.submitted.SubmittedVoteResponse;
+import com.moa.moa_server.domain.vote.service.VoteListService;
 import com.moa.moa_server.domain.vote.service.VoteService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.*;
 public class VoteController {
 
   private final VoteService voteService;
+  private final VoteListService voteListService;
 
   @Operation(summary = "투표 등록", description = "지정한 그룹 또는 전체 공개로 새 투표를 생성합니다.")
   @PostMapping
@@ -79,7 +81,7 @@ public class VoteController {
       @RequestParam(required = false) Long groupId,
       @RequestParam(required = false) String cursor,
       @RequestParam(required = false) Integer size) {
-    ActiveVoteResponse response = voteService.getActiveVotes(userId, groupId, cursor, size);
+    ActiveVoteResponse response = voteListService.getActiveVotes(userId, groupId, cursor, size);
     return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
   }
 
@@ -90,7 +92,7 @@ public class VoteController {
       @RequestParam(required = false) Long groupId,
       @RequestParam(required = false) String cursor,
       @RequestParam(required = false) Integer size) {
-    MyVoteResponse response = voteService.getMyVotes(userId, groupId, cursor, size);
+    MyVoteResponse response = voteListService.getMyVotes(userId, groupId, cursor, size);
     return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
   }
 
@@ -101,7 +103,8 @@ public class VoteController {
       @RequestParam(required = false) Long groupId,
       @RequestParam(required = false) String cursor,
       @RequestParam(required = false) Integer size) {
-    SubmittedVoteResponse response = voteService.getSubmittedVotes(userId, groupId, cursor, size);
+    SubmittedVoteResponse response =
+        voteListService.getSubmittedVotes(userId, groupId, cursor, size);
     return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
   }
 

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/mine/MyVoteItem.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/mine/MyVoteItem.java
@@ -18,9 +18,11 @@ public record MyVoteItem(
     @Schema(description = "투표 시작 시각", example = "2025-04-20T12:00:00") LocalDateTime createdAt,
     @Schema(description = "투표 종료 시각", example = "2025-04-21T12:00:00") LocalDateTime closedAt,
     @Schema(description = "항목별 결과 리스트 (voteStatus가 'PENDING', 'REJECTED'인 경우 null)")
-        List<VoteOptionResultWithId> results) {
+        List<VoteOptionResultWithId> results,
+    @Schema(description = "댓글 수", example = "10") int commentsCount) {
 
-  public static MyVoteItem from(Vote vote, List<VoteOptionResultWithId> results) {
+  public static MyVoteItem from(
+      Vote vote, List<VoteOptionResultWithId> results, int commentsCount) {
     String status;
     if (vote.getVoteStatus() == Vote.VoteStatus.REJECTED
         || vote.getVoteStatus() == Vote.VoteStatus.PENDING) {
@@ -36,6 +38,7 @@ public record MyVoteItem(
         status,
         vote.getCreatedAt(),
         vote.getClosedAt(),
-        results);
+        results,
+        commentsCount);
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/dto/response/submitted/SubmittedVoteItem.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/dto/response/submitted/SubmittedVoteItem.java
@@ -14,14 +14,17 @@ public record SubmittedVoteItem(
     @Schema(description = "투표 시작 시각", example = "2025-04-20T12:00:00") LocalDateTime createdAt,
     @Schema(description = "투표 종료 시각", example = "2025-04-21T12:00:00") LocalDateTime closedAt,
     @Schema(description = "항목별 결과 리스트 (voteStatus가 'PENDING', 'REJECTED'인 경우 null)")
-        List<VoteOptionResultWithId> results) {
-  public static SubmittedVoteItem from(Vote vote, List<VoteOptionResultWithId> results) {
+        List<VoteOptionResultWithId> results,
+    @Schema(description = "댓글 수", example = "10") int commentsCount) {
+  public static SubmittedVoteItem from(
+      Vote vote, List<VoteOptionResultWithId> results, int commentsCount) {
     return new SubmittedVoteItem(
         vote.getId(),
         vote.getGroup().getId(),
         vote.getContent(),
         vote.getCreatedAt(),
         vote.getClosedAt(),
-        results);
+        results,
+        commentsCount);
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteListService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteListService.java
@@ -1,0 +1,270 @@
+package com.moa.moa_server.domain.vote.service;
+
+import com.moa.moa_server.domain.comment.service.CommentCountService;
+import com.moa.moa_server.domain.global.cursor.UpdatedAtVoteIdCursor;
+import com.moa.moa_server.domain.global.cursor.VoteClosedCursor;
+import com.moa.moa_server.domain.global.cursor.VotedAtVoteIdCursor;
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
+import com.moa.moa_server.domain.group.repository.GroupRepository;
+import com.moa.moa_server.domain.group.util.GroupLookupHelper;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.handler.UserErrorCode;
+import com.moa.moa_server.domain.user.handler.UserException;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.user.util.AuthUserValidator;
+import com.moa.moa_server.domain.vote.dto.response.active.ActiveVoteItem;
+import com.moa.moa_server.domain.vote.dto.response.active.ActiveVoteResponse;
+import com.moa.moa_server.domain.vote.dto.response.mine.MyVoteItem;
+import com.moa.moa_server.domain.vote.dto.response.mine.MyVoteResponse;
+import com.moa.moa_server.domain.vote.dto.response.submitted.SubmittedVoteItem;
+import com.moa.moa_server.domain.vote.dto.response.submitted.SubmittedVoteResponse;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
+import com.moa.moa_server.domain.vote.handler.VoteException;
+import com.moa.moa_server.domain.vote.model.VoteWithVotedAt;
+import com.moa.moa_server.domain.vote.repository.VoteRepository;
+import com.moa.moa_server.domain.vote.service.vote_result.VoteResultService;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class VoteListService {
+
+  private static final int DEFAULT_PAGE_SIZE = 10;
+  private static final int DEFAULT_UNAUTHENTICATED_PAGE_SIZE = 3;
+
+  private final VoteRepository voteRepository;
+  private final UserRepository userRepository;
+  private final GroupRepository groupRepository;
+  private final GroupMemberRepository groupMemberRepository;
+
+  private final GroupLookupHelper groupLookupHelper;
+  private final VoteResultService voteResultService;
+  private final CommentCountService commentCountService;
+
+  @Transactional(readOnly = true)
+  public ActiveVoteResponse getActiveVotes(
+      @Nullable Long userId,
+      @Nullable Long groupId,
+      @Nullable String cursor,
+      @Nullable Integer size) {
+    int pageSize = (size == null || size <= 0) ? DEFAULT_PAGE_SIZE : size;
+    VoteClosedCursor parsedCursor = cursor != null ? VoteClosedCursor.parse(cursor) : null;
+
+    // 비로그인 요청
+    if (userId == null) {
+      // 공개 그룹만 허용 (groupId가 1이 아닌 경우 거절)
+      Long targetGroupId = (groupId != null) ? groupId : 1L;
+      Group group =
+          groupRepository
+              .findById(targetGroupId)
+              .orElseThrow(() -> new VoteException(VoteErrorCode.GROUP_NOT_FOUND));
+      if (!group.isPublicGroup()) {
+        throw new VoteException(VoteErrorCode.FORBIDDEN);
+      }
+
+      List<Vote> votes =
+          voteRepository.findActiveVotes(
+              List.of(group), parsedCursor, null, DEFAULT_UNAUTHENTICATED_PAGE_SIZE);
+      List<ActiveVoteItem> items = votes.stream().map(ActiveVoteItem::from).toList();
+      return new ActiveVoteResponse(items, null, false, items.size());
+    }
+    // 로그인 사용자 요청
+    else {
+      // 사용자 조회
+      User user = getValidUser(userId);
+
+      // 그룹 목록 수집 및 권한 검사
+      List<Group> accessibleGroups = getAccessibleGroups(user, groupId);
+
+      // 투표 목록 조회
+      List<Vote> votes =
+          voteRepository.findActiveVotes(accessibleGroups, parsedCursor, user, pageSize + 1);
+
+      // 응답 구성
+      boolean hasNext = votes.size() > pageSize;
+      if (hasNext) votes = votes.subList(0, pageSize);
+
+      String nextCursor =
+          votes.isEmpty()
+              ? null
+              : new VoteClosedCursor(votes.getLast().getClosedAt(), votes.getLast().getCreatedAt())
+                  .encode();
+
+      List<ActiveVoteItem> items = votes.stream().map(ActiveVoteItem::from).toList();
+      return new ActiveVoteResponse(items, nextCursor, hasNext, items.size());
+    }
+  }
+
+  @Transactional
+  public MyVoteResponse getMyVotes(
+      Long userId, @Nullable Long groupId, @Nullable String cursor, @Nullable Integer size) {
+    int pageSize = (size == null || size <= 0) ? DEFAULT_PAGE_SIZE : size;
+    UpdatedAtVoteIdCursor parsedCursor =
+        cursor != null ? UpdatedAtVoteIdCursor.parse(cursor) : null;
+    if (cursor != null && !voteRepository.existsById(parsedCursor.voteId())) {
+      throw new VoteException(VoteErrorCode.VOTE_NOT_FOUND);
+    }
+
+    // 유저 조회 및 검증
+    User user = getValidUser(userId);
+
+    // 조회 대상 그룹 목록 수집
+    List<Group> groups;
+    if (groupId != null) {
+      // 특정 그룹이 지정된 경우
+      Group group =
+          groupRepository
+              .findById(groupId)
+              .orElseThrow(() -> new VoteException(VoteErrorCode.GROUP_NOT_FOUND));
+      groups = List.of(group);
+    } else {
+      // 전체 그룹 조회: 유저가 속한 그룹 + 공개 그룹
+      groups = groupMemberRepository.findAllActiveGroupsByUser(user);
+
+      Group publicGroup = groupLookupHelper.getPublicGroup();
+      if (!groups.contains(publicGroup)) {
+        groups.add(publicGroup);
+      }
+    }
+
+    // 사용자가 생성한 투표 목록 조회
+    List<Vote> votes = voteRepository.findMyVotes(user, groups, parsedCursor, pageSize + 1);
+
+    // 응답 구성
+    boolean hasNext = votes.size() > pageSize;
+    if (hasNext) votes = votes.subList(0, pageSize);
+
+    String nextCursor =
+        votes.isEmpty()
+            ? null
+            : new UpdatedAtVoteIdCursor(votes.getLast().getUpdatedAt(), votes.getLast().getId())
+                .encode();
+
+    // 댓글 수 집계하여 포함
+    List<Long> voteIds = votes.stream().map(Vote::getId).toList();
+    Map<Long, Integer> commentCounts = commentCountService.getCommentCountsByVoteIds(voteIds);
+
+    // 각 투표별 집계 결과를 포함한 응답 DTO 구성
+    List<MyVoteItem> items =
+        votes.stream()
+            .map(
+                vote -> {
+                  var results = voteResultService.getResultsWithVoteId(vote);
+                  int commentsCount = commentCounts.getOrDefault(vote.getId(), 0);
+                  return MyVoteItem.from(vote, results, commentsCount);
+                })
+            .toList();
+    return new MyVoteResponse(items, nextCursor, hasNext, items.size());
+  }
+
+  @Transactional
+  public SubmittedVoteResponse getSubmittedVotes(
+      Long userId, @Nullable Long groupId, @Nullable String cursor, @Nullable Integer size) {
+
+    int pageSize = resolvePageSize(size);
+    VotedAtVoteIdCursor parsedCursor = cursor != null ? VotedAtVoteIdCursor.parse(cursor) : null;
+    if (cursor != null && !voteRepository.existsById(parsedCursor.voteId())) {
+      throw new VoteException(VoteErrorCode.VOTE_NOT_FOUND);
+    }
+
+    // 유저 조회 및 검증
+    User user = getValidUser(userId);
+
+    // 조회 대상 그룹 목록 수집
+    List<Group> groups;
+    if (groupId != null) {
+      // 특정 그룹이 지정된 경우
+      Group group =
+          groupRepository
+              .findById(groupId)
+              .orElseThrow(() -> new VoteException(VoteErrorCode.GROUP_NOT_FOUND));
+      groups = List.of(group);
+    } else {
+      // 전체 그룹 조회: 유저가 속한 그룹 + 공개 그룹
+      groups = groupMemberRepository.findAllActiveGroupsByUser(user);
+      Group publicGroup = groupLookupHelper.getPublicGroup();
+      if (!groups.contains(publicGroup)) {
+        groups.add(publicGroup);
+      }
+    }
+
+    // 참여한 투표 목록 조회
+    List<VoteWithVotedAt> votes =
+        voteRepository.findSubmittedVotes(user, groups, parsedCursor, pageSize + 1);
+
+    // 응답 구성
+    boolean hasNext = votes.size() > pageSize;
+    if (hasNext) votes = votes.subList(0, pageSize);
+
+    String nextCursor =
+        votes.isEmpty()
+            ? null
+            : new VotedAtVoteIdCursor(votes.getLast().votedAt(), votes.getLast().vote().getId())
+                .encode();
+
+    // 댓글 수 집계하여 포함
+    List<Long> voteIds = votes.stream().map(v -> v.vote().getId()).toList();
+    Map<Long, Integer> commentCounts = commentCountService.getCommentCountsByVoteIds(voteIds);
+
+    // 각 투표별 집계 결과를 포함한 응답 DTO 구성
+    List<SubmittedVoteItem> items =
+        votes.stream()
+            .map(
+                v -> {
+                  var results = voteResultService.getResultsWithVoteId(v.vote());
+                  int commentsCount = commentCounts.getOrDefault(v.vote().getId(), 0);
+                  return SubmittedVoteItem.from(v.vote(), results, commentsCount);
+                })
+            .toList();
+    return new SubmittedVoteResponse(items, nextCursor, hasNext, items.size());
+  }
+
+  private User getValidUser(Long userId) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    AuthUserValidator.validateActive(user);
+    return user;
+  }
+
+  private int resolvePageSize(@Nullable Integer size) {
+    return (size == null || size <= 0) ? DEFAULT_PAGE_SIZE : size;
+  }
+
+  /**
+   * 접근 가능한 그룹 목록 조회 (투표 리스트 조회에 사용) - groupId가 지정된 경우: 해당 그룹만 조회 (권한 확인 포함) - groupId가 없는 경우: 공개 그룹
+   * + 사용자가 속한 모든 그룹 반환
+   */
+  private List<Group> getAccessibleGroups(User user, @Nullable Long groupId) {
+    if (groupId != null) {
+      // 단일 그룹만 조회 (권한 확인 포함)
+      Group group =
+          groupRepository
+              .findById(groupId)
+              .orElseThrow(() -> new VoteException(VoteErrorCode.GROUP_NOT_FOUND));
+
+      if (!group.isPublicGroup()) {
+        groupMemberRepository
+            .findByGroupAndUser(group, user)
+            .orElseThrow(() -> new VoteException(VoteErrorCode.FORBIDDEN));
+      }
+
+      return List.of(group);
+    }
+
+    // 전체 그룹 조회: 공개 그룹 + 사용자의 그룹
+    Group publicGroup = groupLookupHelper.getPublicGroup();
+    List<Group> userGroups = groupMemberRepository.findAllActiveGroupsByUser(user);
+
+    return Stream.concat(Stream.of(publicGroup), userGroups.stream()).distinct().toList();
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -1,8 +1,5 @@
 package com.moa.moa_server.domain.vote.service;
 
-import com.moa.moa_server.domain.global.cursor.UpdatedAtVoteIdCursor;
-import com.moa.moa_server.domain.global.cursor.VoteClosedCursor;
-import com.moa.moa_server.domain.global.cursor.VotedAtVoteIdCursor;
 import com.moa.moa_server.domain.global.util.XssUtil;
 import com.moa.moa_server.domain.group.entity.Group;
 import com.moa.moa_server.domain.group.entity.GroupMember;
@@ -23,27 +20,19 @@ import com.moa.moa_server.domain.vote.dto.response.VoteDeleteResponse;
 import com.moa.moa_server.domain.vote.dto.response.VoteDetailResponse;
 import com.moa.moa_server.domain.vote.dto.response.VoteModerationReasonResponse;
 import com.moa.moa_server.domain.vote.dto.response.VoteUpdateResponse;
-import com.moa.moa_server.domain.vote.dto.response.active.ActiveVoteItem;
-import com.moa.moa_server.domain.vote.dto.response.active.ActiveVoteResponse;
-import com.moa.moa_server.domain.vote.dto.response.mine.MyVoteItem;
-import com.moa.moa_server.domain.vote.dto.response.mine.MyVoteResponse;
 import com.moa.moa_server.domain.vote.dto.response.result.VoteOptionResult;
 import com.moa.moa_server.domain.vote.dto.response.result.VoteResultResponse;
-import com.moa.moa_server.domain.vote.dto.response.submitted.SubmittedVoteItem;
-import com.moa.moa_server.domain.vote.dto.response.submitted.SubmittedVoteResponse;
 import com.moa.moa_server.domain.vote.entity.Vote;
 import com.moa.moa_server.domain.vote.entity.VoteModerationLog;
 import com.moa.moa_server.domain.vote.entity.VoteResponse;
 import com.moa.moa_server.domain.vote.handler.VoteErrorCode;
 import com.moa.moa_server.domain.vote.handler.VoteException;
-import com.moa.moa_server.domain.vote.model.VoteWithVotedAt;
 import com.moa.moa_server.domain.vote.repository.VoteModerationLogRepository;
 import com.moa.moa_server.domain.vote.repository.VoteRepository;
 import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
 import com.moa.moa_server.domain.vote.service.vote_result.VoteResultRedisService;
 import com.moa.moa_server.domain.vote.service.vote_result.VoteResultService;
 import com.moa.moa_server.domain.vote.util.VoteValidator;
-import jakarta.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -51,7 +40,6 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -64,9 +52,6 @@ public class VoteService {
 
   @Value("${spring.profiles.active:}")
   private String activeProfile;
-
-  private static final int DEFAULT_PAGE_SIZE = 10;
-  private static final int DEFAULT_UNAUTHENTICATED_PAGE_SIZE = 3;
 
   private final VoteRepository voteRepository;
   private final UserRepository userRepository;
@@ -267,186 +252,6 @@ public class VoteService {
   }
 
   @Transactional(readOnly = true)
-  public ActiveVoteResponse getActiveVotes(
-      @Nullable Long userId,
-      @Nullable Long groupId,
-      @Nullable String cursor,
-      @Nullable Integer size) {
-    int pageSize = (size == null || size <= 0) ? DEFAULT_PAGE_SIZE : size;
-    VoteClosedCursor parsedCursor = cursor != null ? VoteClosedCursor.parse(cursor) : null;
-
-    // 비로그인 요청
-    if (userId == null) {
-      // 공개 그룹만 허용 (groupId가 1이 아닌 경우 거절)
-      Long targetGroupId = (groupId != null) ? groupId : 1L;
-      Group group =
-          groupRepository
-              .findById(targetGroupId)
-              .orElseThrow(() -> new VoteException(VoteErrorCode.GROUP_NOT_FOUND));
-      if (!group.isPublicGroup()) {
-        throw new VoteException(VoteErrorCode.FORBIDDEN);
-      }
-
-      List<Vote> votes =
-          voteRepository.findActiveVotes(
-              List.of(group), parsedCursor, null, DEFAULT_UNAUTHENTICATED_PAGE_SIZE);
-      List<ActiveVoteItem> items = votes.stream().map(ActiveVoteItem::from).toList();
-      return new ActiveVoteResponse(items, null, false, items.size());
-    }
-    // 로그인 사용자 요청
-    else {
-      // 사용자 조회
-      User user =
-          userRepository
-              .findById(userId)
-              .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
-      AuthUserValidator.validateActive(user);
-
-      // 그룹 목록 수집 및 권한 검사
-      List<Group> accessibleGroups = getAccessibleGroups(user, groupId);
-
-      // 투표 목록 조회
-      List<Vote> votes =
-          voteRepository.findActiveVotes(accessibleGroups, parsedCursor, user, pageSize + 1);
-
-      // 응답 구성
-      boolean hasNext = votes.size() > pageSize;
-      if (hasNext) votes = votes.subList(0, pageSize);
-
-      String nextCursor =
-          votes.isEmpty()
-              ? null
-              : new VoteClosedCursor(votes.getLast().getClosedAt(), votes.getLast().getCreatedAt())
-                  .encode();
-
-      List<ActiveVoteItem> items = votes.stream().map(ActiveVoteItem::from).toList();
-      return new ActiveVoteResponse(items, nextCursor, hasNext, items.size());
-    }
-  }
-
-  @Transactional
-  public MyVoteResponse getMyVotes(
-      Long userId, @Nullable Long groupId, @Nullable String cursor, @Nullable Integer size) {
-    int pageSize = (size == null || size <= 0) ? DEFAULT_PAGE_SIZE : size;
-    UpdatedAtVoteIdCursor parsedCursor =
-        cursor != null ? UpdatedAtVoteIdCursor.parse(cursor) : null;
-    if (cursor != null && !voteRepository.existsById(parsedCursor.voteId())) {
-      throw new VoteException(VoteErrorCode.VOTE_NOT_FOUND);
-    }
-
-    // 유저 조회 및 검증
-    User user =
-        userRepository
-            .findById(userId)
-            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
-    AuthUserValidator.validateActive(user);
-
-    // 조회 대상 그룹 목록 수집
-    List<Group> groups;
-    if (groupId != null) {
-      // 특정 그룹이 지정된 경우
-      Group group =
-          groupRepository
-              .findById(groupId)
-              .orElseThrow(() -> new VoteException(VoteErrorCode.GROUP_NOT_FOUND));
-      groups = List.of(group);
-    } else {
-      // 전체 그룹 조회: 유저가 속한 그룹 + 공개 그룹
-      groups = groupMemberRepository.findAllActiveGroupsByUser(user);
-
-      Group publicGroup = groupLookupHelper.getPublicGroup();
-      if (!groups.contains(publicGroup)) {
-        groups.add(publicGroup);
-      }
-    }
-
-    // 사용자가 생성한 투표 목록 조회
-    List<Vote> votes = voteRepository.findMyVotes(user, groups, parsedCursor, pageSize + 1);
-
-    // 응답 구성
-    boolean hasNext = votes.size() > pageSize;
-    if (hasNext) votes = votes.subList(0, pageSize);
-
-    String nextCursor =
-        votes.isEmpty()
-            ? null
-            : new UpdatedAtVoteIdCursor(votes.getLast().getUpdatedAt(), votes.getLast().getId())
-                .encode();
-
-    // 각 투표별 집계 결과를 포함한 응답 DTO 구성
-    List<MyVoteItem> items =
-        votes.stream()
-            .map(
-                vote -> {
-                  var results = voteResultService.getResultsWithVoteId(vote);
-                  return MyVoteItem.from(vote, results);
-                })
-            .toList();
-    return new MyVoteResponse(items, nextCursor, hasNext, items.size());
-  }
-
-  @Transactional
-  public SubmittedVoteResponse getSubmittedVotes(
-      Long userId, @Nullable Long groupId, @Nullable String cursor, @Nullable Integer size) {
-
-    int pageSize = (size == null || size <= 0) ? DEFAULT_PAGE_SIZE : size;
-    VotedAtVoteIdCursor parsedCursor = cursor != null ? VotedAtVoteIdCursor.parse(cursor) : null;
-    if (cursor != null && !voteRepository.existsById(parsedCursor.voteId())) {
-      throw new VoteException(VoteErrorCode.VOTE_NOT_FOUND);
-    }
-
-    // 유저 조회 및 검증
-    User user =
-        userRepository
-            .findById(userId)
-            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
-    AuthUserValidator.validateActive(user);
-
-    // 조회 대상 그룹 목록 수집
-    List<Group> groups;
-    if (groupId != null) {
-      // 특정 그룹이 지정된 경우
-      Group group =
-          groupRepository
-              .findById(groupId)
-              .orElseThrow(() -> new VoteException(VoteErrorCode.GROUP_NOT_FOUND));
-      groups = List.of(group);
-    } else {
-      // 전체 그룹 조회: 유저가 속한 그룹 + 공개 그룹
-      groups = groupMemberRepository.findAllActiveGroupsByUser(user);
-      Group publicGroup = groupLookupHelper.getPublicGroup();
-      if (!groups.contains(publicGroup)) {
-        groups.add(publicGroup);
-      }
-    }
-
-    // 참여한 투표 목록 조회
-    List<VoteWithVotedAt> votes =
-        voteRepository.findSubmittedVotes(user, groups, parsedCursor, pageSize + 1);
-
-    // 응답 구성
-    boolean hasNext = votes.size() > pageSize;
-    if (hasNext) votes = votes.subList(0, pageSize);
-
-    String nextCursor =
-        votes.isEmpty()
-            ? null
-            : new VotedAtVoteIdCursor(votes.getLast().votedAt(), votes.getLast().vote().getId())
-                .encode();
-
-    // 각 투표별 집계 결과를 포함한 응답 DTO 구성
-    List<SubmittedVoteItem> items =
-        votes.stream()
-            .map(
-                v -> {
-                  var results = voteResultService.getResultsWithVoteId(v.vote());
-                  return SubmittedVoteItem.from(v.vote(), results);
-                })
-            .toList();
-    return new SubmittedVoteResponse(items, nextCursor, hasNext, items.size());
-  }
-
-  @Transactional(readOnly = true)
   public VoteModerationReasonResponse getModerationReason(Long userId, Long voteId) {
     // 유저 조회 및 검증
     User user =
@@ -600,34 +405,6 @@ public class VoteService {
         .findByVoteAndUser(vote, user)
         .map(vr -> vr.getOptionNumber() > 0)
         .orElse(false);
-  }
-
-  /**
-   * 접근 가능한 그룹 목록 조회 (투표 리스트 조회에 사용) - groupId가 지정된 경우: 해당 그룹만 조회 (권한 확인 포함) - groupId가 없는 경우: 공개 그룹
-   * + 사용자가 속한 모든 그룹 반환
-   */
-  public List<Group> getAccessibleGroups(User user, @Nullable Long groupId) {
-    if (groupId != null) {
-      // 단일 그룹만 조회 (권한 확인 포함)
-      Group group =
-          groupRepository
-              .findById(groupId)
-              .orElseThrow(() -> new VoteException(VoteErrorCode.GROUP_NOT_FOUND));
-
-      if (!group.isPublicGroup()) {
-        groupMemberRepository
-            .findByGroupAndUser(group, user)
-            .orElseThrow(() -> new VoteException(VoteErrorCode.FORBIDDEN));
-      }
-
-      return List.of(group);
-    }
-
-    // 전체 그룹 조회: 공개 그룹 + 사용자의 그룹
-    Group publicGroup = groupLookupHelper.getPublicGroup();
-    List<Group> userGroups = groupMemberRepository.findAllActiveGroupsByUser(user);
-
-    return Stream.concat(Stream.of(publicGroup), userGroups.stream()).distinct().toList();
   }
 
   public void deleteVoteByGroupId(Long groupId) {


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #241

## 🔥 작업 개요
- 투표 목록 조회 응답에 댓글 수 포함

## 🛠️ 작업 상세
- 참여한 / 내가 만든 / 그룹 투표 목록 조회 시 응답에 댓글 수 필드 추가
- 댓글 수 조회 전용 컴포넌트 `CommentCountService` 추가
- `VoteService`에서 투표 목록 관련 메서드(`getMyVotes()`, `getSubmittedVotes()`)를 `VoteListService`로 분리하여 책임 분산

## 🧪 테스트

* [x] Postman으로 각 투표 목록 API 응답 확인
  
## 💬 기타 논의 사항

* 없음
