### PR TITLE
feat: 그룹 분석 저장 기능을 위한 MongoDB 도입 및 저장 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,9 @@ dependencies {
   // Redis
   implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+  // MongoDB
+  implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
   // AWS
   implementation 'software.amazon.awssdk:s3'
 

--- a/src/main/java/com/moa/moa_server/config/security/SecurityConstants.java
+++ b/src/main/java/com/moa/moa_server/config/security/SecurityConstants.java
@@ -7,6 +7,7 @@ public class SecurityConstants {
     "/api/v1/test/**",
     "/api/v1/ai/votes/moderation/callback",
     "/api/v1/ai/votes",
+    "/api/v1/ai/groups/analysis",
     "/swagger-ui/**",
     "v3/api-docs/**",
     "/swagger-resources/**",

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/controller/GroupAnalysisCommandController.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/controller/GroupAnalysisCommandController.java
@@ -1,0 +1,32 @@
+package com.moa.moa_server.domain.groupanalysis.controller;
+
+import com.moa.moa_server.domain.global.dto.ApiResponse;
+import com.moa.moa_server.domain.groupanalysis.dto.AIGroupAnalysisCreateRequest;
+import com.moa.moa_server.domain.groupanalysis.dto.AIGroupAnalysisCreateResponse;
+import com.moa.moa_server.domain.groupanalysis.service.GroupAnalysisService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "AIAnalysis", description = "AI 서버가 호출하는 그룹 분석 도메인 API")
+@RestController
+@RequestMapping("/api/v1/ai/groups/analysis")
+@RequiredArgsConstructor
+public class GroupAnalysisCommandController {
+
+  private final GroupAnalysisService groupAnalysisService;
+
+  @Operation(summary = "그룹 분석 데이터 저장", description = "AI가 생성한 그룹 주간 분석 데이터를 저장합니다.")
+  @PostMapping
+  public ResponseEntity<ApiResponse<AIGroupAnalysisCreateResponse>> createAIGroupAnalysis(
+      @RequestBody AIGroupAnalysisCreateRequest request) {
+    AIGroupAnalysisCreateResponse response = groupAnalysisService.createAIGroupAnalysis(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("SUCCESS", response));
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/dto/AIGroupAnalysisCreateRequest.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/dto/AIGroupAnalysisCreateRequest.java
@@ -1,0 +1,16 @@
+package com.moa.moa_server.domain.groupanalysis.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "그룹 분석 저장 요청 DTO")
+public record AIGroupAnalysisCreateRequest(
+    @Schema(description = "분석 대상 그룹 ID", example = "123") Long groupId,
+    @Schema(description = "분석 대상 주차의 시작 시각", example = "2025-06-30T00:00:00")
+        LocalDateTime weekStartAt,
+    @Schema(description = "투표 및 댓글 내용 요약") OverviewDto overview,
+    @Schema(description = "그룹 전체 분위기 정보") SentimentDto sentiment,
+    @Schema(description = "모델이 생성한 총평 문장 리스트", example = "[\"참여율이 높았습니다\", \"긍정적인 피드백이 많았습니다\"]")
+        List<String> modelReview,
+    @Schema(description = "AI 분석 모델 버전", example = "1.0.0") String version) {}

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/dto/AIGroupAnalysisCreateResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/dto/AIGroupAnalysisCreateResponse.java
@@ -1,0 +1,8 @@
+package com.moa.moa_server.domain.groupanalysis.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "그룹 분석 저장 응답 DTO")
+public record AIGroupAnalysisCreateResponse(
+    @Schema(description = "저장된 그룹 ID", example = "123") Long groupId,
+    @Schema(description = "저장 성공 여부", example = "true") boolean created) {}

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/dto/OverviewDto.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/dto/OverviewDto.java
@@ -1,0 +1,10 @@
+package com.moa.moa_server.domain.groupanalysis.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "투표 및 댓글 내용 요약")
+public record OverviewDto(
+    @Schema(description = "투표 요약", example = "그룹원들은 주로 카떼부에 대한 다양한 의견과 경험을 공유했습니다.")
+        String voteSummary,
+    @Schema(description = "댓글 요약", example = "댓글들은 대체로 긍정적이며, 서로를 격려하고 응원하는 내용이 많았습니다.")
+        String commentSummary) {}

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/dto/SentimentDto.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/dto/SentimentDto.java
@@ -1,0 +1,10 @@
+package com.moa.moa_server.domain.groupanalysis.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "그룹 전체 분위기 정보")
+public record SentimentDto(
+    @Schema(description = "감성", example = "긍정적") String emotion,
+    @Schema(description = "주요 키워드", example = "[\"카테부\", \"성장\", \"점심\", \"응원\", \"특강\"]")
+        List<String> topKeywords) {}

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/entity/GroupAnalysis.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/entity/GroupAnalysis.java
@@ -1,5 +1,6 @@
 package com.moa.moa_server.domain.groupanalysis.entity;
 
+import com.moa.moa_server.domain.group.entity.Group;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.*;
@@ -9,15 +10,18 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@Table(name = "group_analysis")
+@Table(
+    name = "group_analysis",
+    uniqueConstraints = {@UniqueConstraint(columnNames = {"group_id", "week_start_at"})})
 public class GroupAnalysis {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(name = "group_id", nullable = false)
-  private Long groupId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "group_id", nullable = false)
+  private Group group;
 
   @Column(name = "week_start_at", nullable = false)
   private LocalDateTime weekStartAt;
@@ -31,5 +35,14 @@ public class GroupAnalysis {
   @PrePersist
   public void onCreate() {
     this.generatedAt = LocalDateTime.now();
+  }
+
+  public static GroupAnalysis of(
+      Group group, LocalDateTime weekStartAt, LocalDateTime publishedAt) {
+    return GroupAnalysis.builder()
+        .group(group)
+        .weekStartAt(weekStartAt)
+        .publishedAt(publishedAt)
+        .build();
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/entity/GroupAnalysis.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/entity/GroupAnalysis.java
@@ -1,0 +1,35 @@
+package com.moa.moa_server.domain.groupanalysis.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "group_analysis")
+public class GroupAnalysis {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "group_id", nullable = false)
+  private Long groupId;
+
+  @Column(name = "week_start_at", nullable = false)
+  private LocalDateTime weekStartAt;
+
+  @Column(name = "generated_at", nullable = false, updatable = false)
+  private LocalDateTime generatedAt;
+
+  @Column(name = "published_at")
+  private LocalDateTime publishedAt;
+
+  @PrePersist
+  public void onCreate() {
+    this.generatedAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/handler/GroupAnalysisErrorCode.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/handler/GroupAnalysisErrorCode.java
@@ -1,0 +1,21 @@
+package com.moa.moa_server.domain.groupanalysis.handler;
+
+import com.moa.moa_server.domain.global.exception.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum GroupAnalysisErrorCode implements BaseErrorCode {
+  INVALID_TIME(HttpStatus.BAD_REQUEST),
+  DUPLICATE_ANALYSIS(HttpStatus.CONFLICT),
+  MONGO_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR),
+  ;
+
+  private final HttpStatus status;
+
+  GroupAnalysisErrorCode(HttpStatus status) {
+    this.status = status;
+  }
+
+  public HttpStatus getStatus() {
+    return status;
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/handler/GroupAnalysisException.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/handler/GroupAnalysisException.java
@@ -1,0 +1,10 @@
+package com.moa.moa_server.domain.groupanalysis.handler;
+
+import com.moa.moa_server.domain.global.exception.BaseErrorCode;
+import com.moa.moa_server.domain.global.exception.BaseException;
+
+public class GroupAnalysisException extends BaseException {
+  public GroupAnalysisException(BaseErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/mapper/GroupAnalysisContentMapper.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/mapper/GroupAnalysisContentMapper.java
@@ -1,0 +1,27 @@
+package com.moa.moa_server.domain.groupanalysis.mapper;
+
+import com.moa.moa_server.domain.groupanalysis.dto.AIGroupAnalysisCreateRequest;
+import com.moa.moa_server.domain.groupanalysis.entity.GroupAnalysis;
+import com.moa.moa_server.domain.groupanalysis.mongo.GroupAnalysisContent;
+
+public class GroupAnalysisContentMapper {
+  public static GroupAnalysisContent toDocument(
+      GroupAnalysis metadata, AIGroupAnalysisCreateRequest analysisContent) {
+    return GroupAnalysisContent.builder()
+        .analysisId(metadata.getId())
+        .groupId(metadata.getGroup().getId())
+        .weekStartAt(metadata.getWeekStartAt())
+        .generatedAt(metadata.getGeneratedAt())
+        .publishedAt(metadata.getPublishedAt())
+        .overview(
+            new GroupAnalysisContent.Overview(
+                analysisContent.overview().voteSummary(),
+                analysisContent.overview().commentSummary()))
+        .sentiment(
+            new GroupAnalysisContent.Sentiment(
+                analysisContent.sentiment().emotion(), analysisContent.sentiment().topKeywords()))
+        .modelReview(analysisContent.modelReview())
+        .source(new GroupAnalysisContent.SourceMeta(analysisContent.version()))
+        .build();
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/mongo/GroupAnalysisContent.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/mongo/GroupAnalysisContent.java
@@ -3,9 +3,11 @@ package com.moa.moa_server.domain.groupanalysis.mongo;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 /**
@@ -17,12 +19,15 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class GroupAnalysisContent {
 
   @Id private String id; // Mongo _id (자동 생성)
 
-  // 메타데이터
+  @Indexed(unique = true)
   private Long analysisId; // MySQL group_analysis.id
+
+  // 메타데이터
   private Long groupId;
   private LocalDateTime weekStartAt;
   private LocalDateTime generatedAt;

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/mongo/GroupAnalysisContent.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/mongo/GroupAnalysisContent.java
@@ -1,0 +1,64 @@
+package com.moa.moa_server.domain.groupanalysis.mongo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * MongoDB에 저장되는 그룹 분석 결과 도큐먼트
+ *
+ * <p>MySQL의 group_analysis 메타데이터와 매핑됨
+ */
+@Document(collection = "group_analysis_content")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupAnalysisContent {
+
+  @Id private String id; // Mongo _id (자동 생성)
+
+  // 메타데이터
+  private Long analysisId; // MySQL group_analysis.id
+  private Long groupId;
+  private LocalDateTime weekStartAt;
+  private LocalDateTime generatedAt;
+  private LocalDateTime publishedAt;
+
+  // AI 분석 내용
+  private Overview overview;
+  private Sentiment sentiment;
+  private List<String> modelReview;
+
+  // 분석 생성 모델 정보
+  private SourceMeta source;
+
+  /** 투표 및 댓글 요약 정보 */
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class Overview {
+    private String voteSummary;
+    private String commentSummary;
+  }
+
+  /** 감성 분석 결과 */
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class Sentiment {
+    private String emotion; // 예: 긍정적, 부정적
+    private List<String> topKeywords; // 주요 키워드 리스트
+  }
+
+  /** 분석 모델 버전 정보 */
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class SourceMeta {
+    private String version; // 모델 버전 (예: "1.0.0")
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/repository/GroupAnalysisJpaRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/repository/GroupAnalysisJpaRepository.java
@@ -1,0 +1,9 @@
+package com.moa.moa_server.domain.groupanalysis.repository;
+
+import com.moa.moa_server.domain.groupanalysis.entity.GroupAnalysis;
+import java.time.LocalDateTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupAnalysisJpaRepository extends JpaRepository<GroupAnalysis, Long> {
+  boolean existsByGroupIdAndWeekStartAt(Long groupId, LocalDateTime weekStartAt);
+}

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/repository/GroupAnalysisMongoRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/repository/GroupAnalysisMongoRepository.java
@@ -1,0 +1,6 @@
+package com.moa.moa_server.domain.groupanalysis.repository;
+
+import com.moa.moa_server.domain.groupanalysis.mongo.GroupAnalysisContent;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface GroupAnalysisMongoRepository extends MongoRepository<GroupAnalysisContent, Long> {}

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/service/GroupAnalysisService.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/service/GroupAnalysisService.java
@@ -1,0 +1,95 @@
+package com.moa.moa_server.domain.groupanalysis.service;
+
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.handler.GroupErrorCode;
+import com.moa.moa_server.domain.group.handler.GroupException;
+import com.moa.moa_server.domain.group.repository.GroupRepository;
+import com.moa.moa_server.domain.groupanalysis.dto.AIGroupAnalysisCreateRequest;
+import com.moa.moa_server.domain.groupanalysis.dto.AIGroupAnalysisCreateResponse;
+import com.moa.moa_server.domain.groupanalysis.entity.GroupAnalysis;
+import com.moa.moa_server.domain.groupanalysis.handler.GroupAnalysisErrorCode;
+import com.moa.moa_server.domain.groupanalysis.handler.GroupAnalysisException;
+import com.moa.moa_server.domain.groupanalysis.mapper.GroupAnalysisContentMapper;
+import com.moa.moa_server.domain.groupanalysis.mongo.GroupAnalysisContent;
+import com.moa.moa_server.domain.groupanalysis.repository.GroupAnalysisJpaRepository;
+import com.moa.moa_server.domain.groupanalysis.repository.GroupAnalysisMongoRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GroupAnalysisService {
+
+  private final GroupRepository groupRepository;
+  private final GroupAnalysisJpaRepository analysisJpaRepository;
+  private final GroupAnalysisMongoRepository analysisMongoRepository;
+
+  @Transactional
+  public AIGroupAnalysisCreateResponse createAIGroupAnalysis(AIGroupAnalysisCreateRequest request) {
+    // 입력값 검증
+    Group group =
+        groupRepository
+            .findById(request.groupId())
+            .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+
+    validateWeekStartAt(request.weekStartAt());
+    validateDuplicateAnalysis(group.getId(), request.weekStartAt());
+
+    // MySQL 저장
+    LocalDateTime publishedAt = calculatePublishedAt(request.weekStartAt());
+    GroupAnalysis analysis = GroupAnalysis.of(group, request.weekStartAt(), publishedAt);
+    GroupAnalysis saved = analysisJpaRepository.save(analysis);
+
+    // MongoDB 저장
+    GroupAnalysisContent content = GroupAnalysisContentMapper.toDocument(saved, request);
+    try {
+      analysisMongoRepository.save(content);
+    } catch (Exception e) {
+      log.error(
+          "[GroupAnalysisService#createAIGroupAnalysis] MongoDB 저장 실패: groupId={}, weekStartAt={}",
+          group.getId(),
+          request.weekStartAt(),
+          e);
+      analysisJpaRepository.deleteById(saved.getId()); // 롤백
+      throw new GroupAnalysisException(GroupAnalysisErrorCode.MONGO_SAVE_FAILED);
+    }
+
+    return new AIGroupAnalysisCreateResponse(group.getId(), true);
+  }
+
+  private LocalDateTime calculatePublishedAt(LocalDateTime weekStartAt) {
+    // weekStartAt의 다음 주 월요일 오전 9시(KST)
+    ZoneId koreaZone = ZoneId.of("Asia/Seoul");
+    ZonedDateTime zoned =
+        weekStartAt
+            .atZone(koreaZone)
+            .plusWeeks(1)
+            .withHour(9)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0);
+    return zoned.withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+  }
+
+  private void validateWeekStartAt(LocalDateTime weekStartAt) {
+    // 현재 시점보다 이후인 시작일은 허용하지 않음
+    if (weekStartAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
+      throw new GroupAnalysisException(GroupAnalysisErrorCode.INVALID_TIME);
+    }
+  }
+
+  private void validateDuplicateAnalysis(Long groupId, LocalDateTime weekStartAt) {
+    // 동일 그룹(groupId)의 동일 주차(weekStartAt) 분석 데이터는 유일해야 함
+    boolean exists = analysisJpaRepository.existsByGroupIdAndWeekStartAt(groupId, weekStartAt);
+    if (exists) {
+      throw new GroupAnalysisException(GroupAnalysisErrorCode.DUPLICATE_ANALYSIS);
+    }
+  }
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -17,6 +17,8 @@ spring:
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
       timeout: 5000
+    mongodb:
+      uri: ${MONGODB_URI}
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -19,6 +19,9 @@ spring:
     redis:
       host: localhost
       port: 6379
+    mongodb:
+      uri: ${MONGODB_URI}
+      auto-index-creation: true
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -20,6 +20,8 @@ spring:
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
       timeout: 5000
+    mongodb:
+      uri: ${MONGODB_URI}
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #235

## 🔥 작업 개요
- 그룹 분석 저장 기능을 위한 MongoDB 도입 및 저장 API 구현

## 🛠️ 작업 상세
### 배경
- 그룹 분석 데이터 저장을 위해 MongoDB 도입
  - 이유: 배열, 계층 구조, 유연한 스키마 등 적합
  - 예상 데이터량과 운영 비용 고려해 Cloud 팀과 사용 확정 ([클라우드 이슈 #48](https://github.com/100-hours-a-week/4-bull4zo-cloud/issues/48))

### MongoDB 저장 설계
 - **MySQL에는 메타데이터, MongoDB에는 분석데이터 저장**
   - 메타데이터: `groupId`, `weekStartAt`, `generatedAt`, `publishedAt`
   - 분석데이터: `overview`, `sentiment`, `modelReview`, `version`
   - MongoDB에 `analysisId` (MySQL PK) 저장하여 MySQL → MongoDB 방향으로 조회
  - 분석 데이터는 MySQL 메타데이터 기반으로 조회하며,
  디버깅 편의를 위해 MongoDB에도 동일한 메타데이터를 중복 저장함

### 그룹 분석 저장 기능 구현
- MongoDB 의존성 및 연결 설정 추가
- `groupanalysis` 도메인 생성: Entity, Mongo Document, Service 등 구성
- 그룹 분석 저장 API (`POST /api/v1/ai/groups/analysis`) (AI 서버 → BE)
- 저장 로직
   1. MySQL `group_analysis` 테이블에 메타데이터 저장
   2. MongoDB `group_analysis_content` 컬렉션에 분석데이터 저장
   3. MongoDB 저장 실패 시 MySQL 롤백 및 500 응답

## 🧪 테스트

* [x] 정상 저장 동작 확인 (MySQL 저장 → MongoDB 저장)
* [x] 예외 처리 확인: `INVALID_TIME`, `GROUP_NOT_FOUND`, `DUPLICATE_ANALYSIS`
  
## 💬 기타 논의 사항

develop 병합 전 해야할 일
* [ ] dev 환경 Atlas 생성 및 설정(컬렉션 생성, 인덱스 추가)
* [ ] dev 환경변수 MONGODB_URI 추가

main 병합 전 해야할 일
* [ ] prod 환경 Atlas 생성 및 설정(컬렉션 생성, 인덱스 추가)
* [ ] prod 환경변수 MONGODB_URI 추가
* [ ] prod 환경 group_analysis 테이블 생성
