### PR TITLE
cicd: EKS, MongoDB용 시크릿 추가 주입

### DIFF
--- a/.github/workflows/cicd-docker.yml
+++ b/.github/workflows/cicd-docker.yml
@@ -161,6 +161,7 @@ jobs:
           OTEL_EXPORTER_OTLP_ENDPOINT=${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
           OTEL_EXPORTER_OTLP_HEADERS=${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
           OTEL_RESOURCE_ATTRIBUTES=${{ secrets.OTEL_RESOURCE_ATTRIBUTES }}
+          MONGODB_URI=${{ secrets.MONGODB_URI }}
           EENV
             else
               cat <<EENV | sudo tee /home/cicd/moa-backend.env > /dev/null
@@ -184,6 +185,7 @@ jobs:
           ELASTIC_APM_SERVER_URL=${{ secrets.ELASTIC_APM_SERVER_URL }}
           ELASTIC_APM_SERVICE_NAME=${{ secrets.ELASTIC_APM_SERVICE_NAME }}
           ELASTIC_APM_ENVIRONMENT=${{ secrets.ELASTIC_APM_ENVIRONMENT }}
+          MONGODB_URI=${{ secrets.MONGODB_URI }}
           EENV
             fi
 

--- a/src/main/java/com/moa/moa_server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/moa/moa_server/domain/auth/service/AuthService.java
@@ -25,7 +25,8 @@ public class AuthService {
           "http://localhost:5173/auth/callback",
           "https://b4z.moagenda.com/auth/callback",
           "https://moagenda.com/auth/callback",
-          "http://localhost:8080/api/v1/auth/login/oauth");
+          "http://localhost:8080/api/v1/auth/login/oauth",
+          "https://eks.moagenda.com/auth/callback");
 
   private final Map<String, OAuthLoginStrategy> strategies;
   private final JwtTokenService jwtTokenService;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: moa-server
+  profiles:
+    active: ${SPRING_PROFILE:prod}
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
## 🔥 작업 개요
- EKS, MONGDB용 시크릿 추가 주입

## 🛠️ 작업 상세
- EKS 테스트를 위한 eks.moagenda.com 도메인 카카오 Oauth 허용
- EKS 배포를 위한 application.yaml에서 스프링 프로필 분기 처리
- MongoDB 사용을 위한 클러스터 URI 추가 주입 과정 추가

## 🧪 테스트

* [x] 
