### PR TITLE
fix: AI 투표 자동 오픈을 1시간 단위 스케줄링으로 변경

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/vote/scheduler/AIVoteOpenScheduler.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/scheduler/AIVoteOpenScheduler.java
@@ -17,7 +17,7 @@ public class AIVoteOpenScheduler {
 
   private final VoteRepository voteRepository;
 
-  @Scheduled(cron = "0 5 10 * * *", zone = "Asia/Seoul") // 초 분 시 일 월 요일
+  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul") // 초 분 시 일 월 요일 (1시간)
   @Transactional
   public void openAIVotes() {
     LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #254

## 🔥 작업 개요
- AI 투표 자동 오픈을 위한 스케줄링 주기 변경

## 🛠️ 작업 상세
- 배경: 오전 10시로 고정되었던 AI 투표 시작 시간이 랜덤 시간으로 변경됨에 따라 스케줄링 변경
- 하루 1회 오전 10시 05분 (KST) → 1시간 단위로 변경

## 🧪 테스트

* 없음
  
## 💬 기타 논의 사항

* 없음
