### PR TITLE
release: v3.1.0

### DIFF
--- a/.github/workflows/cicd-docker.yml
+++ b/.github/workflows/cicd-docker.yml
@@ -3,7 +3,7 @@ name: SpringBoot Docker CI/CD - Unified
 on:
   push:
     branches:
-      - main
+#      - main
       - develop
       - cicd/**
       - release/**

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.moa'
-version = 'v3.0.0'
+version = 'v3.1.0'
 
 java {
 	toolchain {

--- a/src/main/java/com/moa/moa_server/domain/vote/scheduler/AIVoteOpenScheduler.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/scheduler/AIVoteOpenScheduler.java
@@ -17,7 +17,7 @@ public class AIVoteOpenScheduler {
 
   private final VoteRepository voteRepository;
 
-  @Scheduled(cron = "0 5 10 * * *", zone = "Asia/Seoul") // 초 분 시 일 월 요일
+  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul") // 초 분 시 일 월 요일 (1시간)
   @Transactional
   public void openAIVotes() {
     LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);


### PR DESCRIPTION
## 내용

이번 버전(v3.1.0)에는 AI 투표 상태 변경 스케줄러의 실행 주기가 조정되었습니다.

### 기능 변경

#### AI 투표 상태 변경 스케줄러
* `PENDING` 상태의 AI 투표를 시작 시간(`openAt`)에 맞춰 `OPEN`으로 전환하는 스케줄러
   * 기존: 매일 오전 10시 5분(KST) 1회 실행 → 변경: 매 1시간마다 정각(KST) 실행