### PR TITLE
feat: 랭킹 점수 스케줄러 구현 및 수정된 투표 추적 기능 추가

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/repository/CommentRepository.java
@@ -19,4 +19,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
 
   @Query("SELECT c.vote.id, COUNT(c) FROM Comment c WHERE c.vote.id IN :voteIds GROUP BY c.vote.id")
   List<Object[]> countCommentsByVoteIds(@Param("voteIds") List<Long> voteIds);
+
+  int countByVoteId(Long voteId);
 }

--- a/src/main/java/com/moa/moa_server/domain/comment/service/CommentService.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/service/CommentService.java
@@ -15,6 +15,7 @@ import com.moa.moa_server.domain.comment.util.CommentNicknameUtil;
 import com.moa.moa_server.domain.global.cursor.CreatedAtCommentIdCursor;
 import com.moa.moa_server.domain.global.util.XssUtil;
 import com.moa.moa_server.domain.notification.application.producer.VoteNotificationProducerImpl;
+import com.moa.moa_server.domain.ranking.service.RankingRedisService;
 import com.moa.moa_server.domain.user.entity.User;
 import com.moa.moa_server.domain.vote.entity.Vote;
 import com.moa.moa_server.domain.vote.repository.VoteRepository;
@@ -32,6 +33,7 @@ public class CommentService {
 
   private final CommentRepository commentRepository;
   private final VoteRepository voteRepository;
+  private final RankingRedisService rankingRedisService;
 
   private final VoteNotificationProducerImpl voteNotificationProducer;
 
@@ -68,6 +70,9 @@ public class CommentService {
             request.anonymous(), anonymousNumber, user.getNickname());
 
     voteNotificationProducer.notifyVoteCommented(voteId, userId, comment.getContent());
+
+    // 랭킹 갱신을 위해 수정된 투표를 Redis ZSet에 기록
+    rankingRedisService.trackUpdatedVote(voteId);
 
     return new CommentCreateResponse(
         comment.getId(), comment.getContent(), authorNickname, comment.getCreatedAt());

--- a/src/main/java/com/moa/moa_server/domain/ranking/scheduler/RankingScheduler.java
+++ b/src/main/java/com/moa/moa_server/domain/ranking/scheduler/RankingScheduler.java
@@ -25,7 +25,7 @@ public class RankingScheduler {
   private final CommentRepository commentRepository;
   private final VoteResponseRepository voteResponseRepository;
 
-  @Scheduled(cron = "0 * * * * *") // 매 정시
+  @Scheduled(cron = "0 0 * * * *") // 매 정시
   public void updateVoteRanking() {
     // 1. 최근 1시간 내로 수정된 투표 가져오기
     Set<String> updatedVoteIds = getRecentlyModifiedVotes();
@@ -46,7 +46,7 @@ public class RankingScheduler {
           "ranking:"
               + vote.getGroup().getId()
               + ":"
-              + LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
+              + LocalDate.now(ZoneOffset.UTC).format(DateTimeFormatter.BASIC_ISO_DATE);
       redisTemplate.opsForZSet().add(key, voteIdStr, score);
     }
 

--- a/src/main/java/com/moa/moa_server/domain/ranking/scheduler/RankingScheduler.java
+++ b/src/main/java/com/moa/moa_server/domain/ranking/scheduler/RankingScheduler.java
@@ -1,0 +1,76 @@
+package com.moa.moa_server.domain.ranking.scheduler;
+
+import com.moa.moa_server.domain.comment.repository.CommentRepository;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.repository.VoteRepository;
+import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingScheduler {
+
+  private final StringRedisTemplate redisTemplate;
+  private final VoteRepository voteRepository;
+  private final CommentRepository commentRepository;
+  private final VoteResponseRepository voteResponseRepository;
+
+  @Scheduled(cron = "0 * * * * *") // 매 정시
+  public void updateVoteRanking() {
+    // 1. 최근 1시간 내로 수정된 투표 가져오기
+    Set<String> updatedVoteIds = getRecentlyModifiedVotes();
+
+    for (String voteIdStr : updatedVoteIds) {
+      Long voteId = Long.parseLong(voteIdStr);
+      Vote vote = voteRepository.findById(voteId).orElse(null);
+      if (vote == null) continue;
+
+      // 2. 점수 계산
+      int commentCount = commentRepository.countByVoteId(voteId);
+      int responseCount = voteResponseRepository.countByVoteId(voteId);
+      long duration = computeDuration(vote.getOpenAt(), vote.getClosedAt());
+      double score = (commentCount + responseCount) / (double) duration;
+
+      // 3. 랭킹 ZSet에 저장
+      String key =
+          "ranking:"
+              + vote.getGroup().getId()
+              + ":"
+              + LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
+      redisTemplate.opsForZSet().add(key, voteIdStr, score);
+    }
+
+    log.info(
+        "[RankingScheduler#updateVoteRanking] 랭킹 점수 스케줄러 완료 - updatedVotes={}개",
+        updatedVoteIds.size());
+  }
+
+  private Set<String> getRecentlyModifiedVotes() {
+    String key =
+        "ranking:changed:" + LocalDate.now(ZoneOffset.UTC).format(DateTimeFormatter.BASIC_ISO_DATE);
+    long now = Instant.now().getEpochSecond();
+
+    Set<String> raw = redisTemplate.opsForZSet().rangeByScore(key, now - 3600, now);
+
+    if (raw == null || raw.isEmpty()) {
+      return Collections.emptySet();
+    }
+
+    return raw.stream().map(Object::toString).collect(Collectors.toSet());
+  }
+
+  private long computeDuration(LocalDateTime openAt, LocalDateTime closedAt) {
+    long hours = Duration.between(openAt, closedAt).toHours();
+    return Math.max(1, (long) Math.ceil(hours / 24.0));
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/ranking/service/RankingRedisService.java
+++ b/src/main/java/com/moa/moa_server/domain/ranking/service/RankingRedisService.java
@@ -1,0 +1,23 @@
+package com.moa.moa_server.domain.ranking.service;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RankingRedisService {
+
+  private final StringRedisTemplate redisTemplate;
+
+  public void trackUpdatedVote(Long voteId) {
+    String key =
+        "ranking:changed:" + LocalDate.now(ZoneOffset.UTC).format(DateTimeFormatter.BASIC_ISO_DATE);
+    long now = Instant.now().getEpochSecond(); // score: 현재 timestamp
+    redisTemplate.opsForZSet().add(key, voteId.toString(), now);
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResponseRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/repository/VoteResponseRepository.java
@@ -30,4 +30,6 @@ public interface VoteResponseRepository extends JpaRepository<VoteResponse, Long
       @Param("groupId") Long groupId,
       @Param("start") LocalDateTime start,
       @Param("end") LocalDateTime end);
+
+  int countByVoteId(Long voteId);
 }

--- a/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/service/VoteService.java
@@ -5,9 +5,9 @@ import com.moa.moa_server.domain.group.entity.Group;
 import com.moa.moa_server.domain.group.entity.GroupMember;
 import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
 import com.moa.moa_server.domain.group.repository.GroupRepository;
-import com.moa.moa_server.domain.group.util.GroupLookupHelper;
 import com.moa.moa_server.domain.image.model.ImageProcessResult;
 import com.moa.moa_server.domain.image.service.ImageService;
+import com.moa.moa_server.domain.ranking.service.RankingRedisService;
 import com.moa.moa_server.domain.user.entity.User;
 import com.moa.moa_server.domain.user.handler.UserErrorCode;
 import com.moa.moa_server.domain.user.handler.UserException;
@@ -60,12 +60,12 @@ public class VoteService {
   private final VoteResponseRepository voteResponseRepository;
   private final VoteModerationLogRepository voteModerationLogRepository;
 
-  private final GroupLookupHelper groupLookupHelper;
   private final VoteResultService voteResultService;
   private final VoteModerationService voteModerationService;
   private final VoteResultRedisService voteResultRedisService;
   private final ImageService imageService;
   private final VoteRelatedDataCleaner voteRelatedDataCleaner;
+  private final RankingRedisService rankingRedisService;
 
   @Transactional
   public Long createVote(Long userId, VoteCreateRequest request) {
@@ -191,6 +191,8 @@ public class VoteService {
 
     // Redis에 투표 결과 반영
     voteResultRedisService.incrementOptionCount(voteId, response);
+    // 랭킹 갱신을 위해 수정된 투표를 Redis ZSet에 기록
+    rankingRedisService.trackUpdatedVote(voteId);
   }
 
   @Transactional


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #262

## 🔥 작업 개요
- 실시간 그룹 투표 랭킹 생성을 위한 수정된 투표 추적 및 점수 계산 스케줄러 구현

## 🛠️ 작업 상세
* 댓글 작성 또는 투표 참여 발생 시 해당 투표 ID를 Redis ZSet(`ranking:changed:{yyyyMMdd}`)에 기록
  * key는 날짜 기준 UTC, score는 `epochSecond` 기준 UTC 시간 사용

* 매 1시간마다 스케줄러 실행 (`@Scheduled`)
  * 최근 1시간 내 수정된 투표 목록 조회
  * 댓글 수 + 응답 수를 기반으로 점수 계산
    `score = (commentCount + responseCount) / 진행기간(일)`
  * 결과를 그룹별 랭킹 ZSet(`ranking:{groupId}:{yyyyMMdd}`)에 저장

## 🧪 테스트

* [x] 댓글/응답 시 Redis에 해당 투표 ID 기록 확인
* [x] 랭킹 점수 스케줄러 실행 시 랭킹 키에 score 저장 확인
  
## 💬 기타 논의 사항
* 댓글/응답 수는 현재 매 스케줄 시 DB에서 count 조회하고 있음 → 캐싱 여부는 추후 고려
* 캐시 미스/백업 처리, Top3 조회 API는 다음 PR에서 진행 예정
* 랭킹 갱신 간격은 현재 1시간이나, 트래픽에 따라 조정 가능
