### PR TITLE
fix: 전체 그룹의 랭킹 투표 조회 시 공개 그룹 누락 해결 및 불필요 파라미터 제거

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/ranking/controller/RankingController.java
+++ b/src/main/java/com/moa/moa_server/domain/ranking/controller/RankingController.java
@@ -22,10 +22,8 @@ public class RankingController {
   @Operation(summary = "Top3 투표 목록 조회", description = "그룹 내 하루 동안의 Top3 투표 목록을 조회합니다.")
   @GetMapping
   public ResponseEntity<ApiResponse<TopVoteResponse>> getTopVotes(
-      @AuthenticationPrincipal Long userId,
-      @RequestParam @Nullable Long groupId,
-      @RequestParam String type) {
-    TopVoteResponse response = rankingService.getTopVotes(userId, groupId, type);
+      @AuthenticationPrincipal Long userId, @RequestParam @Nullable Long groupId) {
+    TopVoteResponse response = rankingService.getTopVotes(userId, groupId);
     return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/ranking/dto/TopVoteResponse.java
+++ b/src/main/java/com/moa/moa_server/domain/ranking/dto/TopVoteResponse.java
@@ -9,16 +9,14 @@ import lombok.Builder;
 @Schema(description = "Top3 투표 조회 응답 DTO")
 public record TopVoteResponse(
     @Schema(description = "그룹 ID", example = "1") Long groupId,
-    @Schema(description = "기간 기준", example = "daily") String type,
     @Schema(description = "랭킹 기준 시작 시간", example = "2025-07-21T00:00:00") LocalDateTime rankedFrom,
     @Schema(description = "랭킹 기준 종료 시간", example = "2025-07-21T01:00:00") LocalDateTime rankedTo,
     @Schema(description = "Top3 투표 목록") List<TopVoteItem> topVotes) {
 
   public static TopVoteResponse of(
-      Long groupId, String type, LocalDateTime from, LocalDateTime to, List<TopVoteItem> votes) {
+      Long groupId, LocalDateTime from, LocalDateTime to, List<TopVoteItem> votes) {
     return TopVoteResponse.builder()
         .groupId(groupId)
-        .type(type)
         .rankedFrom(from)
         .rankedTo(to)
         .topVotes(votes)

--- a/src/main/java/com/moa/moa_server/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/moa/moa_server/domain/ranking/service/RankingService.java
@@ -110,6 +110,7 @@ public class RankingService {
 
   private List<TopVoteItem> getTopVotesByAllGroups(User user) {
     List<Long> groupIds = groupMemberRepository.findGroupIdsByUser(user);
+    groupIds.add(1L); // 공개 그룹 포함
 
     return groupIds.stream()
         .flatMap(gid -> getTopVotesWithScore(gid).stream())


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #265

## 🔥 작업 개요
- 전체 그룹 랭킹 조회 시 공개 그룹 포함 처리
- 랭킹 API에서 불필요한 type 파라미터 제거

## 🛠️ 작업 상세

- 전체 그룹 대상 랭킹 조회 시 공개 그룹이 누락되던 문제를 수정
  - 공개 그룹은 `group_member` 테이블에 포함되지 않으므로,
    사용자가 속한 그룹 목록에 공개 그룹(`id=1`)을 수동으로 포함

- Top3 투표 목록 조회 API (`GET /api/v1/votes/top`) 파라미터 수정
  - 기획 변경에 따라 `type`(daily/weekly) 파라미터 제거

## 🧪 테스트

* [x] `groupId=null` 요청 시 공개 그룹 포함 확인
* [x] `groupId=1` 단일 조회 정상 응답 확인
* [x] 기존 그룹 ID 요청도 정상 동작 확인
  
## 💬 기타 논의 사항

* 없음
