### PR TITLE
fix: 랭킹 투표에 대해 투표 미참여자의 접근 권한 확장

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/ranking/service/RankingRedisService.java
+++ b/src/main/java/com/moa/moa_server/domain/ranking/service/RankingRedisService.java
@@ -1,9 +1,11 @@
 package com.moa.moa_server.domain.ranking.service;
 
+import com.moa.moa_server.domain.vote.entity.Vote;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -19,5 +21,21 @@ public class RankingRedisService {
         "ranking:changed:" + LocalDate.now(ZoneOffset.UTC).format(DateTimeFormatter.BASIC_ISO_DATE);
     long now = Instant.now().getEpochSecond(); // score: 현재 timestamp
     redisTemplate.opsForZSet().add(key, voteId.toString(), now);
+  }
+
+  public boolean isTopRankedVote(Vote vote) {
+    String groupKey =
+        vote.getGroup().isPublicGroup() ? "1" : String.valueOf(vote.getGroup().getId());
+    String key =
+        "ranking:"
+            + groupKey
+            + ":"
+            + LocalDate.now(ZoneOffset.UTC).format(DateTimeFormatter.BASIC_ISO_DATE);
+
+    // Redis ZSet에서 Top3 범위 조회
+    Set<String> top3 = redisTemplate.opsForZSet().reverseRange(key, 0, 2);
+    if (top3 == null) return false;
+
+    return top3.contains(String.valueOf(vote.getId()));
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/ranking/util/RankingPermissionValidator.java
+++ b/src/main/java/com/moa/moa_server/domain/ranking/util/RankingPermissionValidator.java
@@ -1,0 +1,24 @@
+package com.moa.moa_server.domain.ranking.util;
+
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
+import com.moa.moa_server.domain.ranking.service.RankingRedisService;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RankingPermissionValidator {
+
+  private final GroupMemberRepository groupMemberRepository;
+  private final RankingRedisService rankingRedisService;
+
+  public boolean isAccessibleAsTopRankedVote(User user, Vote vote) {
+    // top3 투표는 그룹 멤버인 경우 허용
+    if (!rankingRedisService.isTopRankedVote(vote)) return false;
+    Group group = vote.getGroup();
+    return group.isPublicGroup() || groupMemberRepository.existsByGroupAndUser(group, user);
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #257

## 🔥 작업 개요
- 랭킹 투표에 대해 투표 미참여자도 접근 가능하도록 권한 확장
  - 대상: 투표 내용 조회, 투표 결과 조회, 댓글 작성, 댓글 목록 조회

## 🛠️ 작업 상세
- Redis에 해당 투표가 랭킹 상위 투표(Top3)인지 여부를 확인하여 권한을 부여
- 해당 투표가 랭킹 투표이며, 요청 사용자가 해당 그룹의 멤버이거나 그룹이 공개 그룹인 경우 접근 허용
- 적용 API:
  - `GET /api/v1/votes/{voteId}`
  - `GET /api/v1/votes/{id}/result`
  - `POST /api/v1/comments`
  - `GET /api/v1/comments`

## 🧪 테스트

* [x] Top3 랭킹 투표인 경우 미참여자의 결과/댓글 접근 가능 확인
* [x] 비 Top3 투표에 대해 기존 권한 정책 유지 확인
  
## 💬 기타 논의 사항

* 없음
