### PR TITLE
hotfix: v3.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.moa'
-version = 'v3.2.0'
+version = 'v3.2.1'
 
 java {
 	toolchain {

--- a/src/main/java/com/moa/moa_server/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/moa/moa_server/domain/ranking/service/RankingService.java
@@ -40,7 +40,7 @@ public class RankingService {
   private final GroupRepository groupRepository;
   private final GroupMemberRepository groupMemberRepository;
 
-  @Transactional(readOnly = true)
+  @Transactional
   public TopVoteResponse getTopVotes(Long userId, Long groupId) {
     // 유저/그룹/멤버십 검증
     User user = validateAndGetuser(userId);


### PR DESCRIPTION
## 📌 관련 이슈
- 없음

## 🔥 작업 개요
- Top3 투표 목록 조회 서비스에서 트랜잭션 `readOnly=true` 옵션 제거

## 🛠️ 작업 상세
- `RankingService#getTopVotes` 서비스 메서드에 적용된 `@Transactional(readOnly=true)` 옵션을 제거하였음.

- 배경:
   - Top3 목록 조회 응답에 포함되는 투표 결과를 조회하는 시점에서 
   `vote_result` 테이블 쓰기 작업이 발생하여 SQL 오류가 생기는 문제 해결 목적

   - 테이블 쓰기 작업 발생 경로: 
     ```
     RankingService#getTopVotes → RankingService#toTopVoteItem
       → VoteResultService#getResults → VoteResultResolver#getOrComputeResults
                        → 투표 종료 시각 지난 상태 → VoteResultDbWriter#finalize
      ```
   - 에러 로그
      ```
      Caused by: org.hibernate.exception.GenericJDBCException: could not execute statement 
      [Connection is read-only. Queries leading to data modification are not allowed] 
      [insert into vote_result(count,created_at,option_number,ratio,updated_at,vote_id) values (?,?,?,?,?,?)]
      ```

  
## 💬 기타 논의 사항

* 추후 기획상 변경에 따라 Top3 투표 목록 조회 API 응답에서 `result`가 제거될 예정. 이때는 `@Transactional(readOnly=true)` 옵션 사용에 문제 없음.
