### PR TITLE
feat: Top3 투표 목록 조회 API V2 구현 (결과 제외, 응답 수/댓글 수만 반환)

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/ranking/controller/RankingController.java
+++ b/src/main/java/com/moa/moa_server/domain/ranking/controller/RankingController.java
@@ -2,7 +2,9 @@ package com.moa.moa_server.domain.ranking.controller;
 
 import com.moa.moa_server.domain.global.dto.ApiResponse;
 import com.moa.moa_server.domain.ranking.dto.TopVoteResponse;
+import com.moa.moa_server.domain.ranking.dto.TopVoteResponseV2;
 import com.moa.moa_server.domain.ranking.service.RankingService;
+import com.moa.moa_server.domain.ranking.service.RankingServiceV2;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Nullable;
@@ -14,16 +16,27 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "TopVote", description = "랭킹 투표 도메인 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/votes/top")
+@RequestMapping
 public class RankingController {
 
   private final RankingService rankingService;
+  private final RankingServiceV2 rankingServiceV2;
 
   @Operation(summary = "Top3 투표 목록 조회", description = "그룹 내 하루 동안의 Top3 투표 목록을 조회합니다.")
-  @GetMapping
+  @GetMapping("/api/v1/votes/top")
   public ResponseEntity<ApiResponse<TopVoteResponse>> getTopVotes(
       @AuthenticationPrincipal Long userId, @RequestParam @Nullable Long groupId) {
     TopVoteResponse response = rankingService.getTopVotes(userId, groupId);
+    return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
+  }
+
+  @Operation(
+      summary = "Top3 투표 목록 조회 V2",
+      description = "그룹 내 하루 동안의 Top3 투표 목록을 조회합니다. (내용, 응답 수, 댓글 수만 포함)")
+  @GetMapping("/api/v2/votes/top")
+  public ResponseEntity<ApiResponse<TopVoteResponseV2>> getTopVotesV2(
+      @AuthenticationPrincipal Long userId, @RequestParam @Nullable Long groupId) {
+    TopVoteResponseV2 response = rankingServiceV2.getTopVotesV2(userId, groupId);
     return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/ranking/dto/TopVoteItemV2.java
+++ b/src/main/java/com/moa/moa_server/domain/ranking/dto/TopVoteItemV2.java
@@ -1,0 +1,24 @@
+package com.moa.moa_server.domain.ranking.dto;
+
+import com.moa.moa_server.domain.vote.entity.Vote;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "Top3 투표 정보")
+public record TopVoteItemV2(
+    @Schema(description = "투표 ID", example = "123") Long voteId,
+    @Schema(description = "투표가 속한 그룹 ID", example = "1") Long groupId,
+    @Schema(description = "투표 본문 내용", example = "에어컨 추우신 분?") String content,
+    @Schema(description = "응답 수", example = "10") int responsesCount,
+    @Schema(description = "댓글 수", example = "5") int commentsCount) {
+  public static TopVoteItemV2 from(Vote vote, int responsesCount, int commentsCount) {
+    return TopVoteItemV2.builder()
+        .voteId(vote.getId())
+        .groupId(vote.getGroup().getId())
+        .content(vote.getContent())
+        .responsesCount(responsesCount)
+        .commentsCount(commentsCount)
+        .build();
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/ranking/dto/TopVoteResponseV2.java
+++ b/src/main/java/com/moa/moa_server/domain/ranking/dto/TopVoteResponseV2.java
@@ -1,0 +1,25 @@
+package com.moa.moa_server.domain.ranking.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "Top3 투표 조회 응답 DTO")
+public record TopVoteResponseV2(
+    @Schema(description = "그룹 ID", example = "1") Long groupId,
+    @Schema(description = "랭킹 기준 시작 시간", example = "2025-07-21T00:00:00") LocalDateTime rankedFrom,
+    @Schema(description = "랭킹 기준 종료 시간", example = "2025-07-21T01:00:00") LocalDateTime rankedTo,
+    @Schema(description = "Top3 투표 목록") List<TopVoteItemV2> topVotes) {
+
+  public static TopVoteResponseV2 of(
+      Long groupId, LocalDateTime from, LocalDateTime to, List<TopVoteItemV2> votes) {
+    return TopVoteResponseV2.builder()
+        .groupId(groupId)
+        .rankedFrom(from)
+        .rankedTo(to)
+        .topVotes(votes)
+        .build();
+  }
+}

--- a/src/main/java/com/moa/moa_server/domain/ranking/service/RankingServiceV2.java
+++ b/src/main/java/com/moa/moa_server/domain/ranking/service/RankingServiceV2.java
@@ -1,0 +1,174 @@
+package com.moa.moa_server.domain.ranking.service;
+
+import com.moa.moa_server.domain.comment.repository.CommentRepository;
+import com.moa.moa_server.domain.group.entity.Group;
+import com.moa.moa_server.domain.group.handler.GroupErrorCode;
+import com.moa.moa_server.domain.group.handler.GroupException;
+import com.moa.moa_server.domain.group.repository.GroupMemberRepository;
+import com.moa.moa_server.domain.group.repository.GroupRepository;
+import com.moa.moa_server.domain.ranking.dto.TopVoteItemV2;
+import com.moa.moa_server.domain.ranking.dto.TopVoteResponseV2;
+import com.moa.moa_server.domain.user.entity.User;
+import com.moa.moa_server.domain.user.handler.UserErrorCode;
+import com.moa.moa_server.domain.user.handler.UserException;
+import com.moa.moa_server.domain.user.repository.UserRepository;
+import com.moa.moa_server.domain.user.util.AuthUserValidator;
+import com.moa.moa_server.domain.vote.entity.Vote;
+import com.moa.moa_server.domain.vote.repository.VoteRepository;
+import com.moa.moa_server.domain.vote.repository.VoteResponseRepository;
+import com.moa.moa_server.domain.vote.service.vote_result.VoteResultService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RankingServiceV2 {
+
+  private static final Long PUBLIC_GROUP_ID = 1L;
+
+  private final StringRedisTemplate redisTemplate;
+  private final VoteRepository voteRepository;
+  private final VoteResultService voteResultService;
+  private final UserRepository userRepository;
+  private final GroupRepository groupRepository;
+  private final GroupMemberRepository groupMemberRepository;
+  private final CommentRepository commentRepository;
+  private final VoteResponseRepository voteResponseRepository;
+
+  @Transactional
+  public TopVoteResponseV2 getTopVotesV2(Long userId, Long groupId) {
+    // 유저/그룹/멤버십 검증
+    User user = validateAndGetuser(userId);
+    validateGroupMembership(user, groupId);
+
+    // 랭킹 기준 시간 계산
+    LocalDate date = LocalDate.now(ZoneOffset.UTC);
+    LocalDateTime from = date.atStartOfDay();
+    LocalDateTime to = date.atTime(LocalTime.MAX);
+
+    List<TopVoteItemV2> topItems;
+
+    if (groupId != null) {
+      topItems = getTopVotesByGroup(groupId);
+    } else {
+      topItems = getTopVotesByAllGroups(user);
+    }
+
+    return TopVoteResponseV2.of(groupId, from, to, topItems);
+  }
+
+  private User validateAndGetuser(Long userId) {
+    // 유저 조회 및 활성 상태 확인
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    AuthUserValidator.validateActive(user);
+    return user;
+  }
+
+  private void validateGroupMembership(User user, Long groupId) {
+    // 그룹 ID가 없으면 전체 그룹 조회이므로 검증 생략
+    if (groupId == null) return;
+
+    // 그룹 조회
+    Group group =
+        groupRepository
+            .findById(groupId)
+            .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+
+    // 비공개 그룹이라면 멤버십 확인
+    if (!group.isPublicGroup()) {
+      groupMemberRepository
+          .findByGroupAndUser(group, user)
+          .orElseThrow(() -> new GroupException(GroupErrorCode.FORBIDDEN));
+    }
+  }
+
+  private List<TopVoteItemV2> getTopVotesByGroup(Long groupId) {
+    String key = buildRankingKey(groupId);
+
+    // top3 조회
+    Set<String> voteIds = redisTemplate.opsForZSet().reverseRange(key, 0, 2);
+
+    // top3 데이터가 없으면 빈 리스트 반환
+    if (voteIds == null || voteIds.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    // voteId 리스트를 기반으로 투표 정보 조회 후 TopVoteItem DTO로 변환
+    List<Long> idList = voteIds.stream().map(Long::valueOf).collect(Collectors.toList());
+    List<Vote> votes = voteRepository.findAllById(idList);
+
+    return votes.stream().map(this::toTopVoteItem).collect(Collectors.toList());
+  }
+
+  private List<TopVoteItemV2> getTopVotesByAllGroups(User user) {
+    List<Long> groupIds = groupMemberRepository.findGroupIdsByUser(user);
+    groupIds.add(PUBLIC_GROUP_ID); // 공개 그룹 포함
+
+    return groupIds.stream()
+        .flatMap(gid -> getTopVotesWithScore(gid).stream())
+        .sorted(Map.Entry.<TopVoteItemV2, Double>comparingByValue().reversed())
+        .limit(3)
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toList());
+  }
+
+  private String buildRankingKey(Long groupId) {
+    String base = "ranking";
+    String date = LocalDate.now(ZoneOffset.UTC).format(DateTimeFormatter.BASIC_ISO_DATE);
+    String g = (groupId != null) ? String.valueOf(groupId) : "all";
+    return base + ":" + g + ":" + date; // 예: ranking:3:20250716
+  }
+
+  private List<Map.Entry<TopVoteItemV2, Double>> getTopVotesWithScore(Long groupId) {
+    String key = buildRankingKey(groupId);
+    Set<ZSetOperations.TypedTuple<String>> tuples =
+        redisTemplate.opsForZSet().reverseRangeWithScores(key, 0, 2);
+
+    if (tuples == null || tuples.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<Long> voteIds =
+        tuples.stream()
+            .map(t -> Long.valueOf(Objects.requireNonNull(t.getValue())))
+            .collect(Collectors.toList());
+
+    Map<Long, Double> scoreMap =
+        tuples.stream()
+            .filter(t -> t.getScore() != null && t.getValue() != null)
+            .collect(
+                Collectors.toMap(
+                    t -> Long.valueOf(t.getValue()), // null 아님 보장됨
+                    ZSetOperations.TypedTuple::getScore));
+
+    List<Vote> votes = voteRepository.findAllById(voteIds);
+
+    return votes.stream()
+        .map(
+            vote -> {
+              TopVoteItemV2 topVoteItem = toTopVoteItem(vote);
+              Double score = scoreMap.get(vote.getId());
+              return Map.entry(topVoteItem, score);
+            })
+        .collect(Collectors.toList());
+  }
+
+  private TopVoteItemV2 toTopVoteItem(Vote vote) {
+    int responsesCount = voteResponseRepository.countByVoteId(vote.getId());
+    int commentsCount = commentRepository.countByVoteId(vote.getId());
+    return TopVoteItemV2.from(vote, responsesCount, commentsCount);
+  }
+}


### PR DESCRIPTION
참고: 이 PR에서의 버전은 서비스 버전이 아닌 api 버전을 이야기 합니다.

## 📌 관련 이슈
- Closes #272

## 🔥 작업 개요
- Top3 투표 목록 조회 API V2 구현 (결과 제외, 응답 수/댓글 수만 반환)

## 🛠️ 작업 상세
- 기획 변경에 따라 V2 API 추가 (`GET /api/v2/votes/top`)
- 응답 필드 구성:
  - 투표 ID, 그룹 ID, 내용
  - 응답 수 (`responseCount`)
  - 댓글 수 (`commentCount`)
- 제거된 필드:
  - 투표 결과(응답 비율), 시작/종료 시간

## 🧪 테스트

* [x] 응답 필드 변경 사항 정상 반영 확인
* [x] 그룹 지정 시 Top3 투표 정상 반환
* [x] 그룹 미지정 시 전체 그룹에서 Top3 반환
* [x] 랭킹 캐시가 없는 경우 빈 리스트 반환
  
## 💬 기타 논의 사항

* V2가 프로덕션에 적용되고 안정화되면, V1 관련 API 및 DTO 정리 예정
