### PR TITLE
refactor: VoteList 도메인 분리 및 Swagger 설명 보완

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/comment/controller/CommentPollingController.java
+++ b/src/main/java/com/moa/moa_server/domain/comment/controller/CommentPollingController.java
@@ -8,6 +8,8 @@ import com.moa.moa_server.domain.global.dto.ApiResponse;
 import com.moa.moa_server.domain.global.exception.BaseException;
 import com.moa.moa_server.domain.global.exception.GlobalErrorCode;
 import com.moa.moa_server.domain.global.security.SecurityContextUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.async.DeferredResult;
 
 @Slf4j
+@Tag(name = "Comment")
 @RestController
 @RequestMapping("/api/v1/votes")
 public class CommentPollingController {
@@ -33,6 +36,7 @@ public class CommentPollingController {
     this.executor = executor;
   }
 
+  @Operation(summary = "댓글 목록 롱폴링 조회", description = "지정된 시점 이후로 추가된 댓글을 실시간으로 반환합니다.")
   @GetMapping("/{voteId}/comments/poll")
   public DeferredResult<ResponseEntity<ApiResponse<CommentListResponse>>> pollComments(
       @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/moa/moa_server/domain/groupanalysis/controller/GroupAnalysisQueryController.java
+++ b/src/main/java/com/moa/moa_server/domain/groupanalysis/controller/GroupAnalysisQueryController.java
@@ -21,7 +21,7 @@ public class GroupAnalysisQueryController {
 
   private final GroupAnalysisQueryService groupAnalysisService;
 
-  @Operation()
+  @Operation(summary = "그룹 분석 데이터 조회", description = "그룹 분석 데이터를 조회합니다.")
   @GetMapping("/{groupId}/analysis")
   public ResponseEntity<ApiResponse<GroupAnalysisResponse>> getGroupAnalysis(
       @PathVariable Long groupId, @AuthenticationPrincipal Long userId) {

--- a/src/main/java/com/moa/moa_server/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/moa/moa_server/domain/notification/controller/NotificationController.java
@@ -45,7 +45,10 @@ public class NotificationController {
     return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
   }
 
-  @Operation(summary = "알림 SSE", description = "알림 SSE 커넥션을 열고, SseEmitter를 반환합니다.")
+  @Operation(
+      summary = "알림 SSE",
+      description =
+          "SSE(Server-Sent Events)를 통해 알림 수신을 위한 연결을 생성합니다. 연결이 유지되는 동안 주기적인 ping 이벤트와 실시간 알림 이벤트가 전송됩니다.")
   @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
   public SseEmitter subscribe(
       @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteController.java
@@ -6,10 +6,7 @@ import com.moa.moa_server.domain.vote.dto.request.VoteCreateRequest;
 import com.moa.moa_server.domain.vote.dto.request.VoteSubmitRequest;
 import com.moa.moa_server.domain.vote.dto.request.VoteUpdateRequest;
 import com.moa.moa_server.domain.vote.dto.response.*;
-import com.moa.moa_server.domain.vote.dto.response.active.ActiveVoteResponse;
-import com.moa.moa_server.domain.vote.dto.response.mine.MyVoteResponse;
 import com.moa.moa_server.domain.vote.dto.response.result.VoteResultResponse;
-import com.moa.moa_server.domain.vote.dto.response.submitted.SubmittedVoteResponse;
 import com.moa.moa_server.domain.vote.service.VoteListService;
 import com.moa.moa_server.domain.vote.service.VoteService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -71,40 +68,6 @@ public class VoteController {
   public ResponseEntity<ApiResponse<VoteResultResponse>> getVoteResult(
       @AuthenticationPrincipal Long userId, @PathVariable Long voteId) {
     VoteResultResponse response = voteService.getVoteResult(userId, voteId);
-    return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
-  }
-
-  @Operation(summary = "진행 중인 투표 목록 조회", description = "사용자가 참여할 수 있는 진행 중인 투표 목록을 조회합니다.")
-  @GetMapping
-  public ResponseEntity<ApiResponse<ActiveVoteResponse>> getActiveVotes(
-      @AuthenticationPrincipal Long userId,
-      @RequestParam(required = false) Long groupId,
-      @RequestParam(required = false) String cursor,
-      @RequestParam(required = false) Integer size) {
-    ActiveVoteResponse response = voteListService.getActiveVotes(userId, groupId, cursor, size);
-    return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
-  }
-
-  @Operation(summary = "내가 만든 투표 목록 조회", description = "사용자가 등록한 투표 목록을 조회합니다.")
-  @GetMapping("/mine")
-  public ResponseEntity<ApiResponse<MyVoteResponse>> getMyVotes(
-      @AuthenticationPrincipal Long userId,
-      @RequestParam(required = false) Long groupId,
-      @RequestParam(required = false) String cursor,
-      @RequestParam(required = false) Integer size) {
-    MyVoteResponse response = voteListService.getMyVotes(userId, groupId, cursor, size);
-    return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
-  }
-
-  @Operation(summary = "내가 참여한 투표 목록 조회", description = "사용자가 참여한 투표 목록을 조회합니다.")
-  @GetMapping("/submit")
-  public ResponseEntity<ApiResponse<SubmittedVoteResponse>> getSubmittedVotes(
-      @AuthenticationPrincipal Long userId,
-      @RequestParam(required = false) Long groupId,
-      @RequestParam(required = false) String cursor,
-      @RequestParam(required = false) Integer size) {
-    SubmittedVoteResponse response =
-        voteListService.getSubmittedVotes(userId, groupId, cursor, size);
     return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
   }
 

--- a/src/main/java/com/moa/moa_server/domain/vote/controller/VoteListController.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/controller/VoteListController.java
@@ -1,0 +1,61 @@
+package com.moa.moa_server.domain.vote.controller;
+
+import com.moa.moa_server.domain.global.dto.ApiResponse;
+import com.moa.moa_server.domain.vote.dto.response.active.ActiveVoteResponse;
+import com.moa.moa_server.domain.vote.dto.response.mine.MyVoteResponse;
+import com.moa.moa_server.domain.vote.dto.response.submitted.SubmittedVoteResponse;
+import com.moa.moa_server.domain.vote.service.VoteListService;
+import com.moa.moa_server.domain.vote.service.VoteService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "VoteList", description = "투표 목록 도메인 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/votes")
+public class VoteListController {
+
+  private final VoteService voteService;
+  private final VoteListService voteListService;
+
+  @Operation(summary = "진행 중인 투표 목록 조회", description = "사용자가 참여할 수 있는 진행 중인 투표 목록을 조회합니다.")
+  @GetMapping
+  public ResponseEntity<ApiResponse<ActiveVoteResponse>> getActiveVotes(
+      @AuthenticationPrincipal Long userId,
+      @RequestParam(required = false) Long groupId,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) Integer size) {
+    ActiveVoteResponse response = voteListService.getActiveVotes(userId, groupId, cursor, size);
+    return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
+  }
+
+  @Operation(summary = "내가 만든 투표 목록 조회", description = "사용자가 등록한 투표 목록을 조회합니다.")
+  @GetMapping("/mine")
+  public ResponseEntity<ApiResponse<MyVoteResponse>> getMyVotes(
+      @AuthenticationPrincipal Long userId,
+      @RequestParam(required = false) Long groupId,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) Integer size) {
+    MyVoteResponse response = voteListService.getMyVotes(userId, groupId, cursor, size);
+    return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
+  }
+
+  @Operation(summary = "내가 참여한 투표 목록 조회", description = "사용자가 참여한 투표 목록을 조회합니다.")
+  @GetMapping("/submit")
+  public ResponseEntity<ApiResponse<SubmittedVoteResponse>> getSubmittedVotes(
+      @AuthenticationPrincipal Long userId,
+      @RequestParam(required = false) Long groupId,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) Integer size) {
+    SubmittedVoteResponse response =
+        voteListService.getSubmittedVotes(userId, groupId, cursor, size);
+    return ResponseEntity.ok(new ApiResponse<>("SUCCESS", response));
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #276

## 🔥 작업 개요
- Swagger 문서 개선 및 도메인 분리를 통해 API 명세의 가독성과 구조 개선

## 🛠️ 작업 상세
1. Vote → VoteList 도메인 분리 (refactor)
   : 진행 중 / 참여한 / 생성한 투표 목록 조회 API를 VoteList 도메인으로 분리
   - 컨트롤러 및 관련 DTO 이동, Swagger 문서에서도 태그 분리 반영

2. Swagger 설명 추가 및 보완 (docs)
   - `NotificationController`: 알림 SSE 구독 API에 description 보완 (ping 이벤트 및 구독 목적 설명 보완)
   - `GroupAnalysisQueryController`: 그룹 분석 데이터 조회 API에 Swagger 설명 추가
   - `CommentPollingController`: 댓글 목록 롱폴링 조회 API에 Swagger 설명 추가

## 🧪 테스트

* [x] Swagger 문서에서 각 API 설명 및 태그 분리 정상 확인
  
## 💬 기타 논의 사항

* 없음
