### PR TITLE
refactor: 알림 처리 성능 개선 및 스레드풀 설정 정비

### DIFF
--- a/src/main/java/com/moa/moa_server/config/AsyncConfig.java
+++ b/src/main/java/com/moa/moa_server/config/AsyncConfig.java
@@ -41,11 +41,14 @@ public class AsyncConfig {
 
   // NotificationHandler 전용 스레드풀
   @Bean(name = "notificationExecutor")
-  public Executor notificationExecutor() {
+  public ThreadPoolTaskExecutor notificationExecutor() {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(3); // 자주 발생하지만 빠르게 끝나는 작업이므로 작게 시작
     executor.setMaxPoolSize(6);
     executor.setQueueCapacity(100); // 초당 수십 건 수준이면 충분
+    executor.setRejectedExecutionHandler(
+        new ThreadPoolExecutor.AbortPolicy() // 작업 거부 및 예외 발생 (FE에서 재요청 유도)
+        ); // 풀이 가득 찼을 때 대응
     executor.setThreadNamePrefix("notification-async-");
     executor.initialize();
     return executor;

--- a/src/main/java/com/moa/moa_server/config/AsyncConfig.java
+++ b/src/main/java/com/moa/moa_server/config/AsyncConfig.java
@@ -1,6 +1,5 @@
 package com.moa.moa_server.config;
 
-import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,7 +13,7 @@ public class AsyncConfig {
   // 기본 비동기 풀 (전제 @Async의 기본)
   // 명시적으로 기본 풀을 등록해 둠
   @Bean(name = "taskExecutor")
-  public Executor taskExecutor() {
+  public ThreadPoolTaskExecutor taskExecutor() {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(5);
     executor.setMaxPoolSize(10);
@@ -27,29 +26,23 @@ public class AsyncConfig {
   // 댓글 롱폴링 전용 스레드풀
   @Bean(name = "commentPollingExecutor")
   public ThreadPoolTaskExecutor commentPollingExecutor() {
-    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-    executor.setCorePoolSize(10); // 스레드풀 크기
-    executor.setMaxPoolSize(20); // 최대 스레드풀 크기
-    executor.setQueueCapacity(200); // 작업 대기 큐 용량 (초과 시 새로운 스레드 생성 또는 거부 정책 적용)
-    executor.setRejectedExecutionHandler(
-        new ThreadPoolExecutor.AbortPolicy() // 작업 거부 및 예외 발생 (FE에서 재요청 유도)
-        ); // 풀이 가득 찼을 때 대응
-    executor.setThreadNamePrefix("comment-polling-"); // 스레드 이름
-    executor.initialize();
-    return executor;
+    return buildExecutor("comment-polling-", 10, 20, 200);
   }
 
-  // NotificationHandler 전용 스레드풀
+  // NotificationHandler (알림 비동기 처리) 전용 스레드풀
   @Bean(name = "notificationExecutor")
   public ThreadPoolTaskExecutor notificationExecutor() {
+    return buildExecutor("notification-async-", 3, 6, 100);
+  }
+
+  private ThreadPoolTaskExecutor buildExecutor(String name, int core, int max, int queue) {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-    executor.setCorePoolSize(3); // 자주 발생하지만 빠르게 끝나는 작업이므로 작게 시작
-    executor.setMaxPoolSize(6);
-    executor.setQueueCapacity(100); // 초당 수십 건 수준이면 충분
+    executor.setCorePoolSize(core); // 스레드풀 크기
+    executor.setMaxPoolSize(max); // 최대 스레드풀 크기
+    executor.setQueueCapacity(queue); // 작업 대기 큐 용량
+    executor.setThreadNamePrefix(name); // 스레드 이름
     executor.setRejectedExecutionHandler(
-        new ThreadPoolExecutor.AbortPolicy() // 작업 거부 및 예외 발생 (FE에서 재요청 유도)
-        ); // 풀이 가득 찼을 때 대응
-    executor.setThreadNamePrefix("notification-async-");
+        new ThreadPoolExecutor.AbortPolicy()); // 풀이 가득 찼을 때 대응 (작업 거부 및 예외 발생)
     executor.initialize();
     return executor;
   }

--- a/src/main/java/com/moa/moa_server/config/AsyncConfig.java
+++ b/src/main/java/com/moa/moa_server/config/AsyncConfig.java
@@ -1,5 +1,6 @@
 package com.moa.moa_server.config;
 
+import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,25 +25,31 @@ public class AsyncConfig {
   }
 
   // 댓글 롱폴링 전용 스레드풀
+  // - 특징: 대기 시간이 길 수 있고, 동시 요청이 많을 수 있음
+  // - 큐/풀 초과 시: 작업 거부 및 예외 발생시켜 클라이언트에게 즉시 실패 응답 → 재요청 유도
   @Bean(name = "commentPollingExecutor")
   public ThreadPoolTaskExecutor commentPollingExecutor() {
-    return buildExecutor("comment-polling-", 10, 20, 200);
+    return buildExecutor("comment-polling-", 10, 20, 200, new ThreadPoolExecutor.AbortPolicy());
   }
 
   // NotificationHandler (알림 비동기 처리) 전용 스레드풀
+  // - 특징: 빠르게 끝나는 경량 작업
+  // - 큐/풀 초과 시: 호출한 스레드에서 처리하여 알림 유실 방지
   @Bean(name = "notificationExecutor")
   public ThreadPoolTaskExecutor notificationExecutor() {
-    return buildExecutor("notification-async-", 3, 6, 100);
+    return buildExecutor(
+        "notification-async-", 3, 6, 100, new ThreadPoolExecutor.CallerRunsPolicy());
   }
 
-  private ThreadPoolTaskExecutor buildExecutor(String name, int core, int max, int queue) {
+  // 공통 executor 생성 로직
+  private ThreadPoolTaskExecutor buildExecutor(
+      String name, int core, int max, int queue, RejectedExecutionHandler handler) {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(core); // 스레드풀 크기
     executor.setMaxPoolSize(max); // 최대 스레드풀 크기
     executor.setQueueCapacity(queue); // 작업 대기 큐 용량
     executor.setThreadNamePrefix(name); // 스레드 이름
-    executor.setRejectedExecutionHandler(
-        new ThreadPoolExecutor.AbortPolicy()); // 풀이 가득 찼을 때 대응 (작업 거부 및 예외 발생)
+    executor.setRejectedExecutionHandler(handler); // 풀이 가득 찼을 때 대응
     executor.initialize();
     return executor;
   }

--- a/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/moa/moa_server/domain/group/repository/GroupMemberRepository.java
@@ -42,4 +42,8 @@ public interface GroupMemberRepository
 
   @Query("SELECT gm.group.id FROM GroupMember gm WHERE gm.user = :user")
   List<Long> findGroupIdsByUser(@Param("user") User user);
+
+  @Query("select gm.user.id from GroupMember gm where gm.group = :group and gm.user.id <> :ownerId")
+  List<Long> findUserIdsByGroupExcludingOwner(
+      @Param("group") Group group, @Param("ownerId") Long ownerId);
 }

--- a/src/main/java/com/moa/moa_server/domain/notification/application/producer/GroupNotificationProducerImpl.java
+++ b/src/main/java/com/moa/moa_server/domain/notification/application/producer/GroupNotificationProducerImpl.java
@@ -19,15 +19,12 @@ public class GroupNotificationProducerImpl implements NotificationProducer {
   public void notifyAllMembersGroupDeleted(Group group) {
     Long ownerId = group.getUser().getId();
 
-    List<Long> members =
-        groupMemberRepository.findAllByGroup(group).stream()
-            .map(GroupMember -> GroupMember.getUser().getId())
-            .filter(id -> !id.equals(ownerId)) // 그룹 소유자 제외
-            .toList();
+    List<Long> memberIds = groupMemberRepository.findUserIdsByGroupExcludingOwner(group, ownerId);
 
     String content = group.getName() + " 그룹이 삭제되었습니다.";
     NotificationEvent event =
-        NotificationEvent.forMultipleUsers(members, NotificationType.GROUP_DELETED, content, null);
+        NotificationEvent.forMultipleUsers(
+            memberIds, NotificationType.GROUP_DELETED, content, null);
     eventPublisher.publish(event);
   }
 }

--- a/src/main/java/com/moa/moa_server/domain/notification/application/service/NotificationService.java
+++ b/src/main/java/com/moa/moa_server/domain/notification/application/service/NotificationService.java
@@ -1,6 +1,5 @@
 package com.moa.moa_server.domain.notification.application.service;
 
-import com.moa.moa_server.domain.global.cursor.CreatedAtCommentIdCursor;
 import com.moa.moa_server.domain.global.cursor.CreatedAtNotificationIdCursor;
 import com.moa.moa_server.domain.notification.dto.NotificationItem;
 import com.moa.moa_server.domain.notification.dto.NotificationListResponse;
@@ -52,7 +51,7 @@ public class NotificationService {
 
     String nextCursor =
         hasNext
-            ? new CreatedAtCommentIdCursor(
+            ? new CreatedAtNotificationIdCursor(
                     notifications.getLast().getCreatedAt(), notifications.getLast().getId())
                 .encode()
             : null;

--- a/src/main/java/com/moa/moa_server/domain/notification/entity/Notification.java
+++ b/src/main/java/com/moa/moa_server/domain/notification/entity/Notification.java
@@ -36,8 +36,6 @@ public class Notification extends BaseTimeEntity {
   private String redirectUrl;
 
   public void markAsRead() {
-    if (!this.isRead) {
-      this.isRead = true;
-    }
+    this.isRead = true;
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #278
- 이전 PR: #229

## 🔥 작업 개요
- 코드리뷰 피드백을 반영하여, 알림 처리 성능 개선 및 스레드풀 설정 정비

## 🛠️ 작업 상세
- 스레드풀 관련
   - `notificationExecutor`에 `CallerRunsPolicy` 거부 정책 적용
   - `ThreadPoolTaskExecutor` 공통 설정 메서드 `buildExecutor()`로 분리 (`AsyncConfig` 내부)
- 쿼리 최적화
   - `GroupMember`에서 알림 수신자 ID 조회 시, 전체 엔티티가 아닌 `userId`만 조회하도록 JPQL로 쿼리 최적화
- 리팩토링
   - `NotificationHandler#markAsRead()` 메서드 내 불필요한 조건문 제거
   - `NotificationService`에서 잘못 사용된 커서 클래스명(`CreatedAtCommentId`) → `CreatedAtNotificationId`로 수정

## 🧪 테스트

* [x] 비동기 이벤트 정상 처리 확인 (스레드풀 설정 변경 후)
  
## 💬 기타 논의 사항

* 추후 대량 알림 저장 시 JdbcTemplate.batchUpdate() 등 대안 고려 가능성 있음
