### PR TITLE
fix: 그룹 투표 목록 조회 시 PENDING/REJECTED 투표 응답에서 제외

### DIFF
--- a/src/main/java/com/moa/moa_server/domain/vote/repository/impl/VoteRepositoryImpl.java
+++ b/src/main/java/com/moa/moa_server/domain/vote/repository/impl/VoteRepositoryImpl.java
@@ -133,7 +133,12 @@ public class VoteRepositoryImpl implements VoteRepositoryCustom {
     QVote vote = QVote.vote;
 
     BooleanBuilder builder =
-        new BooleanBuilder().and(vote.group.eq(group)).and(vote.deletedAt.isNull());
+        new BooleanBuilder()
+            .and(vote.group.eq(group))
+            .and(vote.deletedAt.isNull())
+            .and(
+                vote.voteStatus.in(
+                    Vote.VoteStatus.OPEN, Vote.VoteStatus.CLOSED)); // PENDING, REJECTED 제외
 
     if (cursor != null) {
       builder.and(


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #256

## 🔥 작업 개요
- 그룹 투표 목록 조회 시 PENDING/REJECTED 투표 응답에서 제외

## 🛠️ 작업 상세
- `VoteRepositoryImpl#findVotesInGroup` 내 BooleanBuilder 수정
  - `OPEN`/`CLOSED` 상태인 투표만 조회하도록 조건 추가

## 🧪 테스트

* 없음
  
## 💬 기타 논의 사항

* 없음
